### PR TITLE
Remove use of deprecated vector get method.

### DIFF
--- a/src/toml.rs
+++ b/src/toml.rs
@@ -184,7 +184,7 @@ impl Value {
                 &Array(ref v) => {
                     let idx: Option<uint> = FromStr::from_str(key);
                     match idx {
-                        Some(idx) if idx < v.len() => cur_value = v.get(idx),
+                        Some(idx) if idx < v.len() => cur_value = &v[idx],
                         _ => return None
                     }
                 },


### PR DESCRIPTION
`#![deny(warnings)]` is preventing compilation with the deprecated `Vec::get` method.
