### PR TITLE
Update uses of move_iter() to into_iter()

### DIFF
--- a/src/test/valid.rs
+++ b/src/test/valid.rs
@@ -33,10 +33,10 @@ fn to_json(toml: Value) -> json::Json {
                 Some(&Table(..)) => true,
                 _ => false,
             };
-            let json = json::List(arr.move_iter().map(to_json).collect());
+            let json = json::List(arr.into_iter().map(to_json).collect());
             if is_table {json} else {doit("array", json)}
         }
-        Table(table) => json::Object(table.move_iter().map(|(k, v)| {
+        Table(table) => json::Object(table.into_iter().map(|(k, v)| {
             (k, to_json(v))
         }).collect()),
     }


### PR DESCRIPTION
This was preventing master from building after the most recent `rustup`. This commit just performs the necessary renaming.
