### PR TITLE
Update show to print an error instead of failing

### DIFF
--- a/src/show.rs
+++ b/src/show.rs
@@ -36,8 +36,9 @@ impl fmt::Show for Value {
             Datetime(ref s) => write!(f, "{}", s),
             Array(ref a) => {
                 match a.as_slice().head() {
-                    Some(&Table(..)) => fail!("invalid toml array of tables"),
-                    _ => {}
+                   Some(&Table(..)) =>
+                       try!(write!(f, "invalid toml array of tables")),
+                   _ => {}
                 }
                 write!(f, "{}", a)
             }
@@ -166,4 +167,3 @@ mod tests {
                     test = \"wut\"\n")
     }
 }
-


### PR DESCRIPTION
These are the changes we discussed a few weeks ago, just slipped my mind, and figured I would submit them at the same time as my other PR.

 I removed the use of `fail!` in the `Show` implementation. I just changed the line that was failing with a message to print said message instead.

Note: These changes won't build without my other PR which removes uses of `move_iter()`.
