### PR TITLE
Remove allow(visible_private_types)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@
 #![crate_type = "lib"]
 #![feature(macro_rules)]
 #![deny(warnings, missing_doc)]
-#![allow(visible_private_types)]
 
 extern crate serialize;
 


### PR DESCRIPTION
It's not needed and no longer supported by rustc anyway.
