### PR TITLE
Export DecodeErrorKind c-tors publicly for #21.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ pub use serialization::{Encoder, encode, encode_str};
 pub use serialization::{Decoder, decode, decode_str};
 pub use serialization::{Error, NeedsKey, NoValue};
 pub use serialization::{InvalidMapKeyLocation, InvalidMapKeyType};
+pub use serialization::{DecodeError, ApplicationError, ExpectedField};
+pub use serialization::{ExpectedMapElement, ExpectedMapKey, NoEnumVariants};
+pub use serialization::{ExpectedType, NilTooLong};
 
 mod parser;
 mod show;


### PR DESCRIPTION
As mentioned in issue #21 this PR exports the DecodeErrorKind constructors publicly in `lib.rs` to allow DecodeErr handling.
