### PR TITLE
Update to namespaced enum variants.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,15 @@ use std::string;
 pub use parser::{Parser, ParserError};
 pub use serialization::{Encoder, encode, encode_str};
 pub use serialization::{Decoder, decode, decode_str};
-pub use serialization::{Error, NeedsKey, NoValue};
-pub use serialization::{InvalidMapKeyLocation, InvalidMapKeyType};
-pub use serialization::{DecodeError, ApplicationError, ExpectedField};
-pub use serialization::{ExpectedMapElement, ExpectedMapKey, NoEnumVariants};
-pub use serialization::{ExpectedType, NilTooLong};
+pub use serialization::Error;
+pub use serialization::Error::{NeedsKey, NoValue};
+pub use serialization::Error::{InvalidMapKeyLocation, InvalidMapKeyType};
+pub use serialization::{DecodeError, DecodeErrorKind};
+pub use serialization::DecodeErrorKind::{ApplicationError, ExpectedField};
+pub use serialization::DecodeErrorKind::{ExpectedMapElement, ExpectedMapKey, NoEnumVariants};
+pub use serialization::DecodeErrorKind::{ExpectedType, NilTooLong};
+
+pub use Value::{String, Integer, Float, Boolean, Datetime, Array, Table};
 
 mod parser;
 mod show;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,8 @@ use std::error::Error;
 use std::num::FromStrRadix;
 use std::str;
 
-use {Array, Table, Value, Float, Integer, Boolean, Datetime, TomlTable};
+use {Value, TomlTable};
+use Value::{Array, Table, Float, Integer, Boolean, Datetime};
 
 /// Parser for converting a string to a TOML `Value` instance.
 ///
@@ -285,7 +286,7 @@ impl<'a> Parser<'a> {
                 self.eat('\n');
             } else {
                 // empty
-                return Some(::String(ret))
+                return Some(Value::String(ret))
             }
         }
 
@@ -328,7 +329,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        return Some(::String(ret));
+        return Some(Value::String(ret));
 
         fn escape(me: &mut Parser, pos: uint, multiline: bool) -> Option<char> {
             match me.cur.next() {
@@ -447,7 +448,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        return Some(::String(ret));
+        return Some(Value::String(ret));
     }
 
     fn number_or_datetime(&mut self, start: uint) -> Option<Value> {
@@ -768,7 +769,8 @@ impl Error for ParserError {
 
 #[cfg(test)]
 mod tests {
-    use {Table, Parser};
+    use Value::Table;
+    use Parser;
 
     #[test]
     fn crlf() {

--- a/src/show.rs
+++ b/src/show.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
-use {Value, String, Integer, Float, Boolean, Datetime, Array, Table, TomlTable};
+use {Value, TomlTable};
+use Value::{String, Integer, Float, Boolean, Datetime, Array, Table};
 
 struct Printer<'a, 'b:'a> {
     output: &'a mut fmt::Formatter<'b>,
@@ -100,7 +101,8 @@ impl<'a, 'b> Printer<'a, 'b> {
 #[cfg(test)]
 #[allow(warnings)]
 mod tests {
-    use {Value, String, Integer, Float, Boolean, Datetime, Array, Table};
+    use Value;
+    use Value::{String, Integer, Float, Boolean, Datetime, Array, Table};
     use std::collections::TreeMap;
 
     macro_rules! map( ($($k:expr: $v:expr),*) => ({

--- a/src/test/valid.rs
+++ b/src/test/valid.rs
@@ -4,7 +4,8 @@ use std::num::strconv;
 use std::collections::TreeMap;
 use self::serialize::json;
 
-use {Parser, Value, Table, Integer, Float, Boolean, Datetime, Array};
+use {Parser, Value};
+use Value::{Table, Integer, Float, Boolean, Datetime, Array};
 
 fn to_json(toml: Value) -> json::Json {
     fn doit(s: &str, json: json::Json) -> json::Json {
@@ -14,7 +15,7 @@ fn to_json(toml: Value) -> json::Json {
         json::Object(map)
     }
     match toml {
-        ::String(s) => doit("string", json::String(s)),
+        Value::String(s) => doit("string", json::String(s)),
         Integer(i) => doit("integer", json::String(i.to_string())),
         Float(f) => doit("float", json::String({
             let (bytes, _) =


### PR DESCRIPTION
Namespaced enums have now landed, this updates the lib to the changes.

In doubt, I've let the public reexport of `Value`, `Error` and `DecodeErrorKind` variants. They should not be needed any more, but it would require a lot of code update for users.
