### PR TITLE
Remove needless 'old_orphan_check' feature flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@
 //!
 
 #![feature(macro_rules)]
-#![feature(old_orphan_check)]
 #![deny(missing_docs)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
With build on `rustc 0.13.0-nightly (ad9e75938 2015-01-05 00:26:28 +0000)`, we needless this feature flag.