### PR TITLE
Merge with HEAD and update serde to pass all tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
+rust:
+  - 1.0.0
+  - beta
+  - nightly
 sudo: false
+before_script:
+  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo build --verbose
   - cargo build --verbose --no-default-features
@@ -7,17 +13,18 @@ script:
   - cargo test --verbose --features serde
   - rustdoc --test README.md -L target
   - cargo doc --no-deps
-after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  [ $TRAVIS_PULL_REQUEST = false ] &&
-  echo '<meta http-equiv=refresh content=0;url=toml/index.html>' > target/doc/index.html &&
-  pip install ghp-import --user $USER &&
-  $HOME/.local/bin/ghp-import -n target/doc &&
-  git push -qf https://${TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages
+after_success:
+  - travis-cargo --only nightly doc-upload
+  - travis-cargo coveralls --no-sudo
 env:
   global:
-    - secure: FO8GVrtHAn5GTj4LOz2BApC3tAEsMbNzvH5UVmCIeNKPuVcKcI3oWNJC/KMCvuJZhu96J3okfRLBxBJrhxsp/YT4fS4kibhZDm6AzbCqxz6AmvHJo2d0jztoRyuLwLSkhwW8vM4VeHH+Tf4PeC56YmnpUGkccHMMidxytJzx8qI=
-    - secure: WVCzGVsthRub6ezJU15xzo+ahlUoZEwvZDeMPmjIMf1G28ObE9Y4BeUNW0j9CxCjyQ+5S0mrp1l0TESN326XTDosigabDiGnKyr5wfncnreN3PCUi3gx7NI+bRTy9B3eV318BhuCDgLgRWLWufCyPtkgAdT6cl+u6p+bEh+vyxo=
+    secure: LZMkQQJT5LqLQQ8JyakjvHNqqMPy8lm/SyC+H5cKUVI/xk7xRuti4eKY937N8uSmbff2m9ZYlG6cNwIOfk/nWn8YsqxA8Wg/xugubWzqGuqu+NQ4IZVa7INT2Fiqyk5SPCh8B5fo2x7OBJ24SCkWb2p8bEWAuW8XdZZOdmi3H2I=
 notifications:
   email:
     on_success: never
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "toml"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # toml-rs
 
 [![Build Status](https://travis-ci.org/alexcrichton/toml-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/toml-rs)
+[![Coverage Status](https://coveralls.io/repos/alexcrichton/toml-rs/badge.svg?branch=master&service=github)](https://coveralls.io/github/alexcrichton/toml-rs?branch=master)
 
-[Documentation](http://alexcrichton.com/toml-rs/toml/index.html)
+[Documentation](http://alexcrichton.com/toml-rs)
 
 A [TOML][toml] decoder and encoder for Rust. This library is currently compliant with
 the v0.4.0 version of TOML. This library will also likely continue to stay up to

--- a/examples/toml2json.rs
+++ b/examples/toml2json.rs
@@ -1,0 +1,57 @@
+#![deny(warnings)]
+
+extern crate toml;
+extern crate rustc_serialize;
+
+use std::fs::File;
+use std::env;
+use std::io;
+use std::io::prelude::*;
+
+use toml::Value;
+use rustc_serialize::json::Json;
+
+fn main() {
+    let mut args = env::args();
+    let mut input = String::new();
+    let filename = if args.len() > 1 {
+        let name = args.nth(1).unwrap();
+        File::open(&name).and_then(|mut f| {
+            f.read_to_string(&mut input)
+        }).unwrap();
+        name
+    } else {
+        io::stdin().read_to_string(&mut input).unwrap();
+        "<stdin>".to_string()
+    };
+
+    let mut parser = toml::Parser::new(&input);
+    let toml = match parser.parse() {
+        Some(toml) => toml,
+        None => {
+            for err in &parser.errors {
+                let (loline, locol) = parser.to_linecol(err.lo);
+                let (hiline, hicol) = parser.to_linecol(err.hi);
+                println!("{}:{}:{}-{}:{} error: {}",
+                         filename, loline, locol, hiline, hicol, err.desc);
+            }
+            return
+        }
+    };
+    let json = convert(Value::Table(toml));
+    println!("{}", json.pretty());
+}
+
+fn convert(toml: Value) -> Json {
+    match toml {
+        Value::String(s) => Json::String(s),
+        Value::Integer(i) => Json::I64(i),
+        Value::Float(f) => Json::F64(f),
+        Value::Boolean(b) => Json::Boolean(b),
+        Value::Array(arr) => Json::Array(arr.into_iter().map(convert).collect()),
+        Value::Table(table) => Json::Object(table.into_iter().map(|(k, v)| {
+            (k, convert(v))
+        }).collect()),
+        Value::Datetime(dt) => Json::String(dt),
+    }
+}

--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -3,13 +3,6 @@ use Value;
 use super::{Decoder, DecodeError, DecodeErrorKind};
 use std::collections::BTreeMap;
 
-struct MapVisitor<'a, I> {
-    iter: I,
-    toml: &'a mut Option<Value>,
-    key: Option<String>,
-    value: Option<Value>,
-}
-
 fn se2toml(err: de::value::Error, ty: &'static str) -> DecodeError {
     match err {
         de::value::Error::SyntaxError => de::Error::syntax(ty),
@@ -59,12 +52,92 @@ impl de::Deserializer for Decoder {
             Some(Value::Table(t)) => {
                 visitor.visit_map(MapVisitor {
                     iter: t.into_iter(),
-                    toml: &mut self.toml,
+                    de: self,
                     key: None,
                     value: None,
                 })
             }
             None => Err(de::Error::end_of_stream()),
+        }
+    }
+
+    fn visit_isize<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_i8<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+    fn visit_i16<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_i32<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_i64<V>(&mut self, mut visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        match self.toml.take() {
+            Some(Value::Integer(f)) => {
+                visitor.visit_i64(f).map_err(|e| se2toml(e, "integer"))
+            }
+            ref found => Err(self.mismatch("integer", found)),
+        }
+    }
+
+    fn visit_usize<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_u8<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+    fn visit_u16<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_u32<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_u64<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_i64(visitor)
+    }
+
+    fn visit_f32<V>(&mut self, visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        self.visit_f64(visitor)
+    }
+
+    fn visit_f64<V>(&mut self, mut visitor: V) -> Result<V::Value, DecodeError>
+        where V: de::Visitor
+    {
+        match self.toml.take() {
+            Some(Value::Float(f)) => {
+                visitor.visit_f64(f).map_err(|e| se2toml(e, "float"))
+            }
+            ref found => Err(self.mismatch("float", found)),
         }
     }
 

--- a/src/decoder/serde.rs
+++ b/src/decoder/serde.rs
@@ -12,8 +12,8 @@ struct MapVisitor<'a, I> {
 
 fn se2toml(err: de::value::Error, ty: &'static str) -> DecodeError {
     match err {
-        de::value::Error::SyntaxError => de::Error::syntax_error(),
-        de::value::Error::EndOfStreamError => de::Error::end_of_stream_error(),
+        de::value::Error::SyntaxError => de::Error::syntax(ty),
+        de::value::Error::EndOfStreamError => de::Error::end_of_stream(),
         de::value::Error::MissingFieldError(s) => {
             DecodeError {
                 field: Some(s.to_string()),
@@ -64,7 +64,7 @@ impl de::Deserializer for Decoder {
                     value: None,
                 })
             }
-            None => Err(de::Error::end_of_stream_error()),
+            None => Err(de::Error::end_of_stream()),
         }
     }
 
@@ -155,7 +155,7 @@ impl<'a, I> de::SeqVisitor for SeqDeserializer<'a, I>
         if self.len == 0 {
             Ok(())
         } else {
-            Err(de::Error::end_of_stream_error())
+            Err(de::Error::end_of_stream())
         }
     }
 
@@ -165,19 +165,19 @@ impl<'a, I> de::SeqVisitor for SeqDeserializer<'a, I>
 }
 
 impl de::Error for DecodeError {
-    fn syntax_error() -> DecodeError {
+    fn syntax(_: &str) -> DecodeError {
         DecodeError { field: None, kind: DecodeErrorKind::SyntaxError }
     }
-    fn end_of_stream_error() -> DecodeError {
+    fn end_of_stream() -> DecodeError {
         DecodeError { field: None, kind: DecodeErrorKind::EndOfStream }
     }
-    fn missing_field_error(name: &'static str) -> DecodeError {
+    fn missing_field(name: &'static str) -> DecodeError {
         DecodeError {
             field: Some(name.to_string()),
             kind: DecodeErrorKind::ExpectedField(None),
         }
     }
-    fn unknown_field_error(name: &str) -> DecodeError {
+    fn unknown_field(name: &str) -> DecodeError {
         DecodeError {
             field: Some(name.to_string()),
             kind: DecodeErrorKind::UnknownField,
@@ -239,7 +239,7 @@ impl<'a, I> de::MapVisitor for MapVisitor<'a, I>
                 }
                 Ok(v)
             },
-            None => Err(de::Error::end_of_stream_error())
+            None => Err(de::Error::end_of_stream())
         }
     }
 

--- a/src/encoder/serde.rs
+++ b/src/encoder/serde.rs
@@ -59,6 +59,24 @@ impl ser::Serializer for Encoder {
         try!(value.serialize(self));
         Ok(())
     }
+    fn visit_newtype_struct<T>(&mut self,
+                               _name: &'static str,
+                               value: T) -> Result<(), Self::Error>
+        where T: ser::Serialize,
+    {
+        // Don't serialize the newtype struct in a tuple.
+        value.serialize(self)
+    }
+    fn visit_newtype_variant<T>(&mut self,
+                                _name: &'static str,
+                                _variant_index: usize,
+                                _variant: &'static str,
+                                value: T) -> Result<(), Self::Error>
+        where T: ser::Serialize,
+    {
+        // Don't serialize the newtype struct variant in a tuple.
+        value.serialize(self)
+    }
 }
 
 impl ser::Serialize for Value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,6 @@
 
 use std::collections::BTreeMap;
 use std::str::FromStr;
-use std::string;
 
 pub use parser::{Parser, ParserError};
 
@@ -77,7 +76,7 @@ pub enum Value {
 pub type Array = Vec<Value>;
 
 /// Type representing a TOML table, payload of the Value::Table variant
-pub type Table = BTreeMap<string::String, Value>;
+pub type Table = BTreeMap<String, Value>;
 
 impl Value {
     /// Tests whether this and another value have the same type.

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -87,7 +87,7 @@ fn application_decode_error() {
          fn deserialize<D: Deserializer>(d: &mut D) -> Result<Range10, D::Error> {
              let x: usize = try!(Deserialize::deserialize(d));
              if x > 10 {
-                 Err(serde::de::Error::syntax_error())
+                 Err(serde::de::Error::syntax("more than 10"))
              } else {
                  Ok(Range10(x))
              }


### PR DESCRIPTION
This gets the serde test suite written back in April to pass all tests. There were a couple major things done:

* Port to serde 0.5.
* Switched over to using 0.5's new newtype struct support, so that a type like `struct Foo(u32)` doesn't have a wrapper struct/tuple.
* Added a `Deserialize::visit_enum` that matches the rustc-serialize's pattern of trying to deserialize a tuple into each variant.
* In order to prevent floats from being casted into integers (and vice versa), I added overrides for `Deserialize::visit_{usize,u8,u16,..,i8,i16,...}` to call a new `Deserialize::visit_i64`, and the same for `f32` and `f64`.
* Rewrote the serde `MapVisitor` to report the field when having an error.