### PR TITLE
Add stable Rust build to Travis-CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust:
   - 1.0.0
+  - stable
   - beta
   - nightly
 sudo: false


### PR DESCRIPTION
Currently stable rust is not being built on Travis-CI.