### PR TITLE
Allow BOM (Byte order mark) in toml

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,6 +190,14 @@ impl<'a> Parser<'a> {
         false
     }
 
+    // Consumes a BOM (Byte Order Mark) if one is next
+    fn bom(&mut self) -> bool {
+        match self.peek(0) {
+            Some((_, '\u{feff}')) => { self.cur.next(); true }
+            _ => false
+        }
+    }
+
     // Consumes whitespace ('\t' and ' ') until another character (or EOF) is
     // reached. Returns if any whitespace was consumed
     fn ws(&mut self) -> bool {
@@ -234,6 +242,7 @@ impl<'a> Parser<'a> {
     /// to determine the cause of the parse failure.
     pub fn parse(&mut self) -> Option<super::Table> {
         let mut ret = TomlTable { values: BTreeMap::new(), defined: false };
+        self.bom();
         while self.peek(0).is_some() {
             self.ws();
             if self.newline() { continue }

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -178,3 +178,6 @@ test!(example3,
 test!(example4,
        include_str!("valid/example-v0.4.0.toml"),
        include_str!("valid/example-v0.4.0.json"));
+test!(example_bom,
+       include_str!("valid/example-bom.toml"),
+       include_str!("valid/example.json"));

--- a/tests/valid/example-bom.toml
+++ b/tests/valid/example-bom.toml
@@ -1,0 +1,5 @@
+﻿best-day-ever = 1987-07-05T17:45:00Z
+
+[numtheory]
+boring = false
+perfection = [6, 28, 496]


### PR DESCRIPTION
If any valid UTF-8 encoded file should be possible to parse, then the parser must be able to handle a leading Byte Order Mark (BOM).