### PR TITLE
Remove floats from the Decoder.toml field when they get parsed

### DIFF
--- a/src/decoder/rustc_serialize.rs
+++ b/src/decoder/rustc_serialize.rs
@@ -57,7 +57,7 @@ impl rustc_serialize::Decoder for Decoder {
     }
     fn read_f64(&mut self) -> Result<f64, DecodeError> {
         match self.toml {
-            Some(Value::Float(f)) => Ok(f),
+            Some(Value::Float(f)) => { self.toml.take(); Ok(f) },
             ref found => Err(self.mismatch("float", found)),
         }
     }


### PR DESCRIPTION
Currently, floats never get removed from the `toml` field, even when they are parsed successfully. read_f64 was missing a call to toml.take()