### PR TITLE
[WIP] Value lookup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,8 +259,9 @@ impl Value {
     /// let no_bar = value.lookup("test.bar");
     /// assert_eq!(no_bar.is_none(), true);
     /// ```
-    pub fn lookup<'a>(&'a mut self, path: &str) -> LookupResult<&'a mut Value> {
-        self.lookup_mut(path).map(|v| v)
+    pub fn lookup<'a>(&'a self, path: &str) -> LookupResult<Value> {
+        let mut clone = self.clone();
+        clone.lookup_mut(path).map(|v| v.clone())
     }
 
     /// Same as Value::lookup() but returns the value mutable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,8 +288,8 @@ impl Value {
         use std::vec::IntoIter;
 
         fn walk_iter<'a>(v: Result<&'a mut Value, LookupError>,
-                         i: &mut IntoIter<Token>) 
-            -> Result<&'a mut Value, LookupError> 
+                         i: &mut IntoIter<Token>)
+            -> Result<&'a mut Value, LookupError>
         {
             let next = i.next();
             v.and_then(move |value| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,11 @@ impl Value {
     /// assert_eq!(no_bar.is_none(), true);
     /// ```
     pub fn lookup<'a>(&'a mut self, path: &str) -> LookupResult<&'a mut Value> {
+        self.lookup_mut(path).map(|v| v)
+    }
+
+    /// Same as Value::lookup() but returns the value mutable
+    pub fn lookup_mut<'a>(&'a mut self, path: &str) -> LookupResult<&'a mut Value> {
         let tokens = Value::tokenize(path);
         if tokens.is_err() {
             return tokens.map(|_| self);


### PR DESCRIPTION
This is an improved version of the `Value::lookup` functionality. It is extracted from https://github.com/matthiasbeyer/imag/pull/149.

**This is highly WIP and not tested yet**

ATM I'm breaking the interface. Please add suggestions and ideas. I plan to implement

* [x] A getter (basically `Value::lookup()`, which returns the `Value` mutable at the moment of writing)
* [ ] A mut getter (`Value::lookup_mut()`)
* [ ] A setter (`Value::set_by_lookupstr()` or something like that)

---

A far-in-the-future goal would be to be able to change the seperator, so you can do something like

```rs
value.lookup_with_sep('/', "foo/bar/1/baz.bar")
```

So we can ship around the `'.'`-is-not-allowed-in-keys issue.