### PR TITLE
Add lookup_mut method for mutable access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,28 @@ mod tests {
     use super::Value;
 
     #[test]
+    fn lookup_mut_change() {
+        let toml = r#"
+              [test]
+              foo = "bar"
+
+              [[values]]
+              foo = "baz"
+
+              [[values]]
+              foo = "qux"
+        "#;
+
+        let mut value: Value = toml.parse().unwrap();
+        {
+          let foo = value.lookup_mut("values.0.foo").unwrap();
+          *foo = Value::String(String::from("bar"));
+        }
+        let foo = value.lookup("values.0.foo").unwrap();
+        assert_eq!(foo.as_str().unwrap(), "bar");
+    }
+
+    #[test]
     fn lookup_mut_valid() {
         let toml = r#"
               [test]


### PR DESCRIPTION
Mutable access may sometimes be desired in order to change values
in the toml table. This can be used for dynamic configurations which
will be easy to modify and store.

lookup_mut requires a recursive method due to the borrow checker
not allowing to have more than one mutable reference in the same
scope.