### PR TITLE
Allow advanced lookups in lookup and lookup_mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,4 +445,13 @@ mod tests {
         assert_eq!(*looked, Value::Integer(0));
     }
 
+    #[test]
+    fn lookup_mut_advanced() {
+        let mut value: Value = "[table]\n\"value\" = [0, 1, 2]".parse().unwrap();
+        let looked = value.lookup_mut("table.\"value\".1").unwrap();
+        assert_eq!(*looked, Value::Integer(1));
+    }
+
+
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,6 +459,34 @@ mod tests {
         assert_eq!(*looked, Value::Integer(1));
     }
 
+    #[test]
+    fn single_dot() {
+        let value: Value = "[table]\n\"value\" = [0, 1, 2]".parse().unwrap();
+        assert_eq!(None, value.lookup("."));
+    }
 
+    #[test]
+    fn array_dot() {
+        let value: Value = "[table]\n\"value\" = [0, 1, 2]".parse().unwrap();
+        assert_eq!(None, value.lookup("0."));
+    }
+
+    #[test]
+    fn dot_inside() {
+        let value: Value = "[table]\n\"value\" = [0, 1, 2]".parse().unwrap();
+        assert_eq!(None, value.lookup("table.\"value.0\""));
+    }
+
+    #[test]
+    fn table_with_quotes() {
+        let value: Value = "[table.\"element\"]\n\"value\" = [0, 1, 2]".parse().unwrap();
+        assert_eq!(None, value.lookup("\"table.element\".\"value\".0"));
+    }
+
+    #[test]
+    fn table_with_quotes_2() {
+        let value: Value = "[table.\"element\"]\n\"value\" = [0, 1, 2]".parse().unwrap();
+        assert_eq!(Value::Integer(0), *value.lookup("table.\"element\".\"value\".0").unwrap());
+    }
 
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,12 +445,12 @@ mod tests {
         assert_eq!(*looked, Value::Integer(0));
     }
 
-		#[test]
-		fn lookup_advanced_table() {
+    #[test]
+    fn lookup_advanced_table() {
         let value: Value = r#"[table."name.other"] value = "my value""#.parse().unwrap();
         let looked = value.lookup(r#"table."name.other".value"#).unwrap();
         assert_eq!(*looked, Value::String(String::from("my value")));
-		}
+    }
 
     #[test]
     fn lookup_mut_advanced() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,6 +445,13 @@ mod tests {
         assert_eq!(*looked, Value::Integer(0));
     }
 
+		#[test]
+		fn lookup_advanced_table() {
+        let value: Value = r#"[table."name.other"] value = "my value""#.parse().unwrap();
+        let looked = value.lookup(r#"table."name.other".value"#).unwrap();
+        assert_eq!(*looked, Value::String(String::from("my value")));
+		}
+
     #[test]
     fn lookup_mut_advanced() {
         let mut value: Value = "[table]\n\"value\" = [0, 1, 2]".parse().unwrap();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -292,22 +292,7 @@ impl<'a> Parser<'a> {
 
     // Parse an array index as a natural number
     fn array_index(&mut self) -> Option<String> {
-        let mut index = String::new();
-        while let Some((_, ch)) = self.peek(0) {
-            match ch {
-                v @ '0' ... '9' => {
-                    if !self.eat(v) {
-                        return None
-                    }
-                    index.push(v);
-                }
-                _ => return Some(index),
-            }
-        }
-        if index.len() > 0 {
-            return Some(index);
-        }
-        None
+        self.integer(0, false, false)
     }
 
     /// Parse a path into a vector of paths


### PR DESCRIPTION
These commits allow one to search for tables with unconventional names. Example:

```rust
let table: toml::Value = r#"[table."name.other"] value = 0"#.parse().unwrap();
let look = table.lookup(r#"table."name.other".value"#).unwrap();
```

These commits have some breaking changes for the tests, as sending a raw " into lookup will no longer work correctly. One must send `r#""\"""#` or `"\"\\\"\""` instead.

Performance: It may be possible to have a slight performance decrease for all lookups because each entry is now parsed and put into a String. This can be remedied by creating a lookup_simple method that takes simple names only.

Bugs discovered: the parser fails to parse "" and '' as a key name.