### PR TITLE
Fix wrong handling of unicode escape code

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,3 @@
-use std::ascii::AsciiExt;
 use std::char;
 use std::collections::BTreeMap;
 use std::error::Error;
@@ -490,7 +489,7 @@ impl<'a> Parser<'a> {
                 Some((pos, c @ 'U')) => {
                     let len = if c == 'u' {4} else {8};
                     let num = &me.input[pos+1..];
-                    let num = if num.len() >= len && num.is_ascii() {
+                    let num = if num.char_indices().nth(len).map(|(i, _)| i).unwrap_or(0) == len {
                         &num[..len]
                     } else {
                         "invalid"

--- a/tests/valid/unicode-escape.json
+++ b/tests/valid/unicode-escape.json
@@ -1,4 +1,4 @@
 {
-    "answer4": {"type": "string", "value": "\u03B4"},
-    "answer8": {"type": "string", "value": "\u03B4"}
+    "answer4": {"type": "string", "value": "\u03B4α"},
+    "answer8": {"type": "string", "value": "\u03B4β"}
 }

--- a/tests/valid/unicode-escape.toml
+++ b/tests/valid/unicode-escape.toml
@@ -1,2 +1,2 @@
-answer4 = "\u03B4"
-answer8 = "\U000003B4"
+answer4 = "\u03B4α"
+answer8 = "\U000003B4β"


### PR DESCRIPTION
Current parser generates error below if a string contains unicode escape code followed by some unicode character, `"\u03B4α"` for example.

```
expected 4 hex digits after a `u` escape
```

This is an attempt to fix it.