### PR TITLE
Require newline after table

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn lookup_advanced_table() {
-        let value: Value = r#"[table."name.other"] value = "my value""#.parse().unwrap();
+        let value: Value = "[table.\"name.other\"]\nvalue = \"my value\"".parse().unwrap();
         let looked = value.lookup(r#"table."name.other".value"#).unwrap();
         assert_eq!(*looked, Value::String(String::from("my value")));
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -271,6 +271,16 @@ impl<'a> Parser<'a> {
                     values: BTreeMap::new(),
                     defined: true,
                 };
+                self.ws();
+                self.comment();
+                if !self.newline() {
+                    self.errors.push(ParserError {
+                        lo: start,
+                        hi: start,
+                        desc: format!("expected a newline after table definition"),
+                    });
+                    return None
+                }
                 if !self.values(&mut table) { return None }
                 if array {
                     self.insert_array(&mut ret, &keys, Value::Table(table),

--- a/tests/invalid.rs
+++ b/tests/invalid.rs
@@ -50,6 +50,10 @@ test!(float_no_leading_zero,
       include_str!("invalid/float-no-leading-zero.toml"));
 test!(float_no_trailing_digits,
       include_str!("invalid/float-no-trailing-digits.toml"));
+test!(key_after_array,
+      include_str!("invalid/key-after-array.toml"));
+test!(key_after_table,
+      include_str!("invalid/key-after-table.toml"));
 test!(key_empty,
       include_str!("invalid/key-empty.toml"));
 test!(key_hash,

--- a/tests/invalid/key-after-array.toml
+++ b/tests/invalid/key-after-array.toml
@@ -1,0 +1,1 @@
+[[agencies]] owner = "S Cjelli"

--- a/tests/invalid/key-after-table.toml
+++ b/tests/invalid/key-after-table.toml
@@ -1,0 +1,1 @@
+[history] guard = "sleeping"


### PR DESCRIPTION
Currently this library accepts this TOML as valid:

```
[table] key = "value"
```

I'm pretty sure this is not valid TOML. The [spec](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md#table) says:

> They appear in square brackets on a line by themselves

And pytoml rejects the sample TOML above as invalid.

This pull request changes the library to reject TOML that is malformed in this way.

I am not particularly attached to this particular solution, but I'd rather present a PR than a bug report, so I gave it my best, incredibly clumsy, shot. In particular I'm pretty sure the line numbers I put into the ParserError are not right.

An important note:

Because this was previously accepted as valid, this will be a **breaking change for Cargo**. In particular, several versions of servo/rust-url will no longer work with Cargo if this PR is accepted and Cargo updates its toml-rs dependency (see servo/rust-url#186). I think this is the right thing to do, but I want to highlight the potential impact to the Rust ecosystem.