### PR TITLE
Accept empty table

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -285,7 +285,7 @@ impl<'a> Parser<'a> {
                 };
                 if self.require_newline_after_table {
                     self.ws();
-                    if !self.comment() && !self.newline() {
+                    if !self.comment() && !self.newline() && self.peek(0).is_some() {
                         self.errors.push(ParserError {
                             lo: start,
                             hi: start,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1206,6 +1206,14 @@ trimmed in raw strings.
     }
 
     #[test]
+    fn empty_table() {
+        let mut p = Parser::new(r#"
+[foo]"#);
+        let table = Table(p.parse().unwrap());
+        table.lookup("foo").unwrap().as_table().unwrap();
+    }
+
+    #[test]
     fn fruit() {
         let mut p = Parser::new(r#"
 [[fruit]]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -243,6 +243,11 @@ impl<'a> Parser<'a> {
         }
     }
 
+    // Match EOF
+    fn eof(&self) -> bool {
+        self.peek(0).is_none()
+    }
+
     /// Executes the parser, parsing the string contained within.
     ///
     /// This function will return the `TomlTable` instance if parsing is
@@ -285,7 +290,7 @@ impl<'a> Parser<'a> {
                 };
                 if self.require_newline_after_table {
                     self.ws();
-                    if !self.comment() && !self.newline() && self.peek(0).is_some() {
+                    if !self.comment() && !self.newline() && !self.eof() {
                         self.errors.push(ParserError {
                             lo: start,
                             hi: start,


### PR DESCRIPTION
Due to requiring an empty line after a table name, the follow valid (I think, having checked against the grammar) input is now rejected, where it was not before:

```
[table]
```

NB that it is still accepted if followed by a blank line:

```
[table]

```

The Cargo.toml files for the crates "decibel" and "water" don't parse without a fix for this.