### PR TITLE
Clippy run and implement Default for State and Enconder

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -126,11 +126,11 @@ impl Decoder {
     fn sub_decoder(&self, toml: Option<Value>, field: &str) -> Decoder {
         Decoder {
             toml: toml,
-            cur_field: if field.len() == 0 {
+            cur_field: if field.is_empty() {
                 self.cur_field.clone()
             } else {
                 match self.cur_field {
-                    None => Some(format!("{}", field)),
+                    None => Some(field.to_string()),
                     Some(ref s) => Some(format!("{}.{}", s, field))
                 }
             },
@@ -172,7 +172,7 @@ impl fmt::Display for DecodeError {
             ExpectedType(expected, found) => {
                 fn humanize(s: &str) -> String {
                     if s == "section" {
-                        format!("a section")
+                        "a section".to_string()
                     } else {
                         format!("a value of type `{}`", s)
                     }

--- a/src/decoder/rustc_serialize.rs
+++ b/src/decoder/rustc_serialize.rs
@@ -171,7 +171,7 @@ impl rustc_serialize::Decoder for Decoder {
         -> Result<T, DecodeError>
         where F: FnOnce(&mut Decoder) -> Result<T, DecodeError>
     {
-        let field = format!("{}", f_name);
+        let field = f_name.to_string();
         let toml = match self.toml {
             Some(Value::Table(ref mut table)) => {
                 table.remove(&field)
@@ -324,7 +324,7 @@ impl rustc_serialize::Decoder for Decoder {
     fn error(&mut self, err: &str) -> DecodeError {
         DecodeError {
             field: self.cur_field.clone(),
-            kind: ApplicationError(format!("{}", err))
+            kind: ApplicationError(err.to_string())
         }
     }
 }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -35,6 +35,7 @@ use {Value, Table};
 /// assert_eq!(e.toml.get(&"foo".to_string()), Some(&Value::Integer(4)))
 /// # }
 /// ```
+#[derive(Default)]
 pub struct Encoder {
     /// Output TOML that is emitted. The current version of this encoder forces
     /// the top-level representation of a structure to be a table.
@@ -71,6 +72,10 @@ enum State {
     NextKey(String),
     NextArray(Vec<Value>),
     NextMapKey,
+}
+
+impl Default for State {
+    fn default() -> State { State::Start }
 }
 
 impl Encoder {

--- a/src/encoder/rustc_serialize.rs
+++ b/src/encoder/rustc_serialize.rs
@@ -47,10 +47,10 @@ impl rustc_serialize::Encoder for Encoder {
         self.emit_value(Value::Float(v))
     }
     fn emit_char(&mut self, v: char) -> Result<(), Error> {
-        self.emit_str(&*format!("{}", v))
+        self.emit_str(&v.to_string())
     }
     fn emit_str(&mut self, v: &str) -> Result<(), Error> {
-        self.emit_value(Value::String(format!("{}", v)))
+        self.emit_value(Value::String(v.to_string()))
     }
     fn emit_enum<F>(&mut self, _name: &str, f: F)
         -> Result<(), Error>
@@ -98,7 +98,7 @@ impl rustc_serialize::Encoder for Encoder {
         where F: FnOnce(&mut Encoder) -> Result<(), Error>
     {
         let old = mem::replace(&mut self.state,
-                               State::NextKey(format!("{}", f_name)));
+                               State::NextKey(f_name.to_string()));
         try!(f(self));
         if self.state != State::Start {
             return Err(NoValue)
@@ -453,7 +453,7 @@ mod tests {
         match a {
             Ok(..) => panic!("should not have decoded"),
             Err(e) => {
-                assert_eq!(format!("{}", e),
+                assert_eq!(e.to_string(),
                            "expected a value of type `integer`, but \
                             found a value of type `float` for the key `bar`");
             }
@@ -471,7 +471,7 @@ mod tests {
         match a {
             Ok(..) => panic!("should not have decoded"),
             Err(e) => {
-                assert_eq!(format!("{}", e),
+                assert_eq!(e.to_string(),
                            "expected a value of type `integer` for the key `bar`");
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,10 +72,10 @@ pub enum Value {
     Table(Table),
 }
 
-/// Type representing a TOML array, payload of the Value::Array variant
+/// Type representing a TOML array, payload of the `Value::Array` variant
 pub type Array = Vec<Value>;
 
-/// Type representing a TOML table, payload of the Value::Table variant
+/// Type representing a TOML table, payload of the `Value::Table` variant
 pub type Table = BTreeMap<String, Value>;
 
 impl Value {
@@ -180,13 +180,13 @@ impl Value {
     /// let no_bar = value.lookup("test.bar");
     /// assert_eq!(no_bar.is_none(), true);
     /// ```
-    pub fn lookup<'a>(&'a self, path: &'a str) -> Option<&'a Value> {
+    pub fn lookup(&self, path: &str) -> Option<&Value> {
         let ref path = match Parser::new(path).lookup() {
             Some(path) => path,
             None => return None,
         };
         let mut cur_value = self;
-        if path.len() == 0 {
+        if path.is_empty() {
             return Some(cur_value)
         }
 
@@ -247,7 +247,7 @@ impl Value {
         };
 
         let mut cur = self;
-        if path.len() == 0 {
+        if path.is_empty() {
             return Some(cur)
         }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,5 @@
 use std::char;
-use std::collections::BTreeMap;
+use std::collections::btree_map::{BTreeMap, Entry};
 use std::error::Error;
 use std::fmt;
 use std::str;
@@ -294,7 +294,7 @@ impl<'a> Parser<'a> {
                         self.errors.push(ParserError {
                             lo: start,
                             hi: start,
-                            desc: format!("expected a newline after table definition"),
+                            desc: "expected a newline after table definition".to_string(),
                         });
                         return None
                     }
@@ -306,8 +306,8 @@ impl<'a> Parser<'a> {
                 } else {
                     self.insert_table(&mut ret, &keys, table, start)
                 }
-            } else {
-                if !self.values(&mut ret) { return None }
+            } else if !self.values(&mut ret) {
+                return None
             }
         }
         if !self.errors.is_empty() {
@@ -324,7 +324,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a path into a vector of paths
     pub fn lookup(&mut self) -> Option<Vec<String>> {
-        if self.input.len() == 0 {
+        if self.input.is_empty() {
             return Some(vec![]);
         }
         let mut keys = Vec::new();
@@ -367,7 +367,7 @@ impl<'a> Parser<'a> {
                 self.errors.push(ParserError {
                     lo: start,
                     hi: start,
-                    desc: format!("expected a key but found an empty string"),
+                    desc: "expected a key but found an empty string".to_string(),
                 });
                 None
             }
@@ -408,7 +408,7 @@ impl<'a> Parser<'a> {
                 self.errors.push(ParserError {
                     lo: key_lo,
                     hi: end,
-                    desc: format!("expected a newline after a key"),
+                    desc: "expected a newline after a key".to_string(),
                 });
                 return false
             }
@@ -443,7 +443,7 @@ impl<'a> Parser<'a> {
                 self.errors.push(ParserError {
                     lo: lo,
                     hi: hi,
-                    desc: format!("expected a value"),
+                    desc: "expected a value".to_string(),
                 });
                 None
             }
@@ -503,7 +503,7 @@ impl<'a> Parser<'a> {
                     self.errors.push(ParserError {
                         lo: start,
                         hi: self.input.len(),
-                        desc: format!("unterminated string literal"),
+                        desc: "unterminated string literal".to_string(),
                     });
                     return None
                 }
@@ -569,7 +569,7 @@ impl<'a> Parser<'a> {
                     me.errors.push(ParserError {
                         lo: pos,
                         hi: pos + 1,
-                        desc: format!("unterminated escape sequence"),
+                        desc: "unterminated escape sequence".to_string(),
                     });
                     None
                 }
@@ -603,7 +603,7 @@ impl<'a> Parser<'a> {
                 self.errors.push(ParserError {
                     lo: start,
                     hi: next,
-                    desc: format!("literal strings cannot contain newlines"),
+                    desc: "literal strings cannot contain newlines".to_string(),
                 });
                 return None
             }
@@ -620,7 +620,7 @@ impl<'a> Parser<'a> {
                     self.errors.push(ParserError {
                         lo: start,
                         hi: self.input.len(),
-                        desc: format!("unterminated string literal"),
+                        desc: "unterminated string literal".to_string(),
                     });
                     return None
                 }
@@ -647,8 +647,8 @@ impl<'a> Parser<'a> {
         let input = &self.input[start..end];
         let ret = if decimal.is_none() &&
                      exponent.is_none() &&
-                     !input.starts_with("+") &&
-                     !input.starts_with("-") &&
+                     !input.starts_with('+') &&
+                     !input.starts_with('-') &&
                      start + 4 == end &&
                      self.eat('-') {
             self.datetime(start)
@@ -670,7 +670,7 @@ impl<'a> Parser<'a> {
             self.errors.push(ParserError {
                 lo: start,
                 hi: end,
-                desc: format!("invalid numeric literal"),
+                desc: "invalid numeric literal".to_string(),
             });
         }
         ret
@@ -693,7 +693,7 @@ impl<'a> Parser<'a> {
                         self.errors.push(ParserError {
                             lo: start,
                             hi: pos,
-                            desc: format!("leading zeroes are not allowed"),
+                            desc: "leading zeroes are not allowed".to_string(),
                         });
                         return None
                     }
@@ -708,7 +708,7 @@ impl<'a> Parser<'a> {
                 self.errors.push(ParserError {
                     lo: pos,
                     hi: pos,
-                    desc: format!("expected start of a numeric literal"),
+                    desc: "expected start of a numeric literal".to_string(),
                 });
                 return None;
             }
@@ -733,7 +733,7 @@ impl<'a> Parser<'a> {
             self.errors.push(ParserError {
                 lo: pos,
                 hi: pos,
-                desc: format!("numeral cannot end with an underscore"),
+                desc: "numeral cannot end with an underscore".to_string(),
             });
             None
         } else {
@@ -830,7 +830,7 @@ impl<'a> Parser<'a> {
             self.errors.push(ParserError {
                 lo: start,
                 hi: start + next,
-                desc: format!("malformed date literal"),
+                desc: "malformed date literal".to_string(),
             });
             None
         };
@@ -907,14 +907,14 @@ impl<'a> Parser<'a> {
 
     fn insert(&mut self, into: &mut TomlTable, key: String, value: Value,
               key_lo: usize) {
-        if into.values.contains_key(&key) {
+        if let Entry::Vacant(entry) = into.values.entry(key.clone()) {
+            entry.insert(value);
+        } else {
             self.errors.push(ParserError {
                 lo: key_lo,
                 hi: key_lo + key.len(),
                 desc: format!("duplicate key: `{}`", key),
-            })
-        } else {
-            into.values.insert(key, value);
+            });
         }
     }
 


### PR DESCRIPTION
Fix a bunch of lints indicated by clippy, most common one was useless `format!`. Most notable change is to implement `Default` for `State` and derive it for `Encoder`. Also closes #102.