### PR TITLE
lookup() and lookup_mut() lifetime enhancements.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl Value {
     /// let no_bar = value.lookup("test.bar");
     /// assert_eq!(no_bar.is_none(), true);
     /// ```
-    pub fn lookup<'a, 'b>(&'a self, path: &'b str) -> Option<&'a Value> {
+    pub fn lookup(&self, path: &str) -> Option<&Value> {
         let ref path = match Parser::new(path).lookup() {
             Some(path) => path,
             None => return None,
@@ -240,7 +240,7 @@ impl Value {
     /// let result = value.lookup_mut("test.foo").unwrap();
     /// assert_eq!(result.as_str().unwrap(), "foo");
     /// ```
-    pub fn lookup_mut<'a, 'b>(&'a mut self, path: &'b str) -> Option<&'a mut Value> {
+    pub fn lookup_mut(&mut self, path: &str) -> Option<&mut Value> {
        let ref path = match Parser::new(path).lookup() {
             Some(path) => path,
             None => return None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@ impl Value {
     /// let no_bar = value.lookup("test.bar");
     /// assert_eq!(no_bar.is_none(), true);
     /// ```
-    pub fn lookup<'a>(&'a self, path: &'a str) -> Option<&'a Value> {
+    pub fn lookup<'a, 'b>(&'a self, path: &'b str) -> Option<&'a Value> {
         let ref path = match Parser::new(path).lookup() {
             Some(path) => path,
             None => return None,
@@ -240,7 +240,7 @@ impl Value {
     /// let result = value.lookup_mut("test.foo").unwrap();
     /// assert_eq!(result.as_str().unwrap(), "foo");
     /// ```
-    pub fn lookup_mut(&mut self, path: &str) -> Option<&mut Value> {
+    pub fn lookup_mut<'a, 'b>(&'a mut self, path: &'b str) -> Option<&'a mut Value> {
        let ref path = match Parser::new(path).lookup() {
             Some(path) => path,
             None => return None,


### PR DESCRIPTION
Rationale:

- The path has nothing to do with the result.
- The path has no need to live as long as the Value/self.
- In some cases it can be hard to actually build a path that meets
  the same lifetime requirements as the Value or String slice result.

I submit to you that lifetime elision will not work with my use cases.
I really need the 'path' lifetime to be completely disassociated from the Value or String slice result.
I tried to provide an example in my original Issue. If my example was confusing or poorly worded please ask me to clean it up and I will happily do so.

Thank you.
