### PR TITLE
Don't space out the first table or array if not needed

### DIFF
--- a/tests/formatting.rs
+++ b/tests/formatting.rs
@@ -1,0 +1,52 @@
+extern crate rustc_serialize;
+extern crate toml;
+use toml::encode_str;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
+struct User {
+    pub name: String,
+    pub surname: String,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
+struct Users {
+    pub user: Vec<User>,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
+struct TwoUsers {
+    pub user0: User,
+    pub user1: User,
+}
+
+#[test]
+fn no_unnecessary_newlines_array() {
+    assert!(!encode_str(&Users {
+            user: vec![
+                    User {
+                        name: "John".to_string(),
+                        surname: "Doe".to_string(),
+                    },
+                    User {
+                        name: "Jane".to_string(),
+                        surname: "Dough".to_string(),
+                    },
+                ],
+        })
+        .starts_with("\n"));
+}
+
+#[test]
+fn no_unnecessary_newlines_table() {
+    assert!(!encode_str(&TwoUsers {
+            user0: User {
+                name: "John".to_string(),
+                surname: "Doe".to_string(),
+            },
+            user1: User {
+                name: "Jane".to_string(),
+                surname: "Dough".to_string(),
+            },
+        })
+        .starts_with("\n"));
+}


### PR DESCRIPTION
Code I used to verify:
```rust
extern crate rustc_serialize;
extern crate toml;
use toml::encode_str;

#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
struct User {
    pub name: String,
    pub surname: String,
}

#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
struct Users {
    pub user: Vec<User>,
}

#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
struct UsersWithString {
    pub string: String,
    pub user: Vec<User>,
}

#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
struct AUserx2 {
    pub user0: User,
    pub user1: User,
}

#[derive(Debug, Clone, Hash, PartialEq, Eq, RustcEncodable, RustcDecodable)]
struct AUserWithString {
    pub string: String,
    pub user: User,
}

fn main() {
    println!("\"{}\"",
             encode_str(&Users {
                 user: vec![
                    User {
                        name: "John".to_string(),
                        surname: "Doe".to_string(),
                    },
                    User {
                        name: "Jane".to_string(),
                        surname: "Dough".to_string(),
                    },
                ],
             }));
    println!("\"{}\"",
             encode_str(&UsersWithString {
                 string: "this one should get spaced out".to_string(),
                 user: vec![
                    User {
                        name: "John".to_string(),
                        surname: "Doe".to_string(),
                    },
                    User {
                        name: "Jane".to_string(),
                        surname: "Dough".to_string(),
                    },
                ],
             }));
    println!("\"{}\"",
             encode_str(&AUserx2 {
                 user0: User {
                     name: "John".to_string(),
                     surname: "Doe".to_string(),
                 },
                 user1: User {
                     name: "Jane".to_string(),
                     surname: "Dough".to_string(),
                 },
             }));
    println!("\"{}\"",
             encode_str(&AUserWithString {
                 string: "this one should get spaced out".to_string(),
                 user: User {
                     name: "John".to_string(),
                     surname: "Doe".to_string(),
                 },
             }));
}
```

Closes #110