### PR TITLE
Value::query()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,6 +573,35 @@ mod tests {
     }
 
     #[test]
+    fn query_valid() {
+        use super::ValueQueryError;
+
+        let toml = r#"
+              [test]
+              foo = "bar"
+
+              [[values]]
+              foo = "baz"
+
+              [[values]]
+              foo = "qux"
+        "#;
+
+        let value: Value = toml.parse().unwrap();
+
+        let test_foo = value.query("test.foo").unwrap();
+        assert_eq!(test_foo.as_str().unwrap(), "bar");
+
+        let foo1 = value.query("values.1.foo").unwrap();
+        assert_eq!(foo1.as_str().unwrap(), "qux");
+
+        assert!(match value.query("test.bar")
+                { Err(ValueQueryError::KeyNotFound) => true, _ => false });
+        assert!(match value.query("test.foo.bar")
+                { Err(ValueQueryError::PathTypeError) => true, _ => false });
+    }
+
+    #[test]
     fn single_dot() {
         let value: Value = "[table]\n\"value\" = [0, 1, 2]".parse().unwrap();
         assert_eq!(None, value.lookup("."));


### PR DESCRIPTION
Not sure whether you're still interested in such a functionality.

My next step would be to add `Value::query_mut()` and then add convenience functions on top to `Value::set_at("foo.bar.baz", Value::String(String::from("foo")))` for example.

If you're interested.

If I get an ACK on this, I would add more tests for this first functionality and get this into mergable state and add the other functionality after this "simple" `Value::query` is merged.
