### PR TITLE
initial attempt at pretty toml strings

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,4 +1,6 @@
+use std::fmt::Write;
 use std::fmt;
+use std::string::{String as StdString};
 
 use Table as TomlTable;
 use Value::{self, String, Integer, Float, Boolean, Datetime, Array, Table};
@@ -205,5 +207,157 @@ mod tests {
                    }).to_string(),
                    "\"foo\\\"bar\" = 2\n\
                     \"foo.bar\" = 2\n");
+    }
+}
+
+
+
+
+/// Encodes an encodable value into a "pretty" TOML string.
+///
+/// This function expects the type given to represent a TOML table in some form.
+/// If encoding encounters an error, then this function will fail the task.
+/// 
+/// "pretty" means the following features of the output are changed:
+/// - strings with newlines characters (`\n`) will use the `'''` form
+///     and span multiple lines
+pub fn encode_str_pretty<'a>(tbl: TomlTable) -> Result<StdString, fmt::Error> {
+    let mut out = StdString::new();
+    {
+        let mut pp = PrettyPrinter { output: &mut out, stack: Vec::new() };
+        try!(pp.print(&tbl));
+    }
+    Ok(out)
+}
+
+fn write_pretty_str(f: &mut StdString, s: &str) -> fmt::Result {
+    try!(write!(f, "'''\n"));
+    for ch in s.chars() {
+        match ch {
+            '\u{8}' => try!(write!(f, "\\b")),
+            '\u{9}' => try!(write!(f, "\\t")),
+            '\u{c}' => try!(write!(f, "\\f")),
+            '\u{d}' => try!(write!(f, "\\r")),
+            '\u{22}' => try!(write!(f, "\\\"")),
+            '\u{5c}' => try!(write!(f, "\\\\")),
+            ch => try!(write!(f, "{}", ch)),
+        }
+    }
+    write!(f, "'''")
+}
+
+// The only thing in this impl that wasn't copy/pasted is
+// - I removed handling arrays of tables (panics)
+// - I added pretty printing strings when the have a \n in them
+impl<'a, 'b> PrettyPrinter<'a, 'b> {
+    fn print(&mut self, table: &'a TomlTable) -> fmt::Result {
+        let mut space_out_first = false;
+        // print out the regular key/value pairs at the top,
+        // including arrays of tables I guess? (who cares)
+        for (k, v) in table.iter() {
+            match *v {
+                Value::Table(..) => continue,
+                Value::Array(ref a) => {
+                    if let Some(&Value::Table(..)) = a.first() {
+                        // not supported in rst
+                        panic!("attempting to serialize an array of tables!")
+                    }
+                }
+                // super special case -- the whole reason this is here!
+                Value::String(ref s) => {
+                    if s.contains('\n') {
+                        try!(write!(self.output, "{} = ", Key(&[k])));
+                        try!(write_pretty_str(self.output, s));
+                        try!(write!(self.output, "\n"));
+                        space_out_first = true;
+                        continue;
+                    }
+                }
+                _ => {}
+            }
+            space_out_first = true;
+            try!(writeln!(self.output, "{} = {}", Key(&[k]), v));
+        }
+        // now go through the table and format the other tables
+        for (i, (k, v)) in table.iter().enumerate() {
+            match *v {
+                Value::Table(ref inner) => {
+                    // store the stack so that we can write
+                    // [table.foo.bar]
+                    self.stack.push(k);
+                    if space_out_first || i != 0 {
+                        try!(write!(self.output, "\n"));
+                    }
+                    try!(writeln!(self.output, "[{}]", Key(&self.stack)));
+                    try!(self.print(inner));
+                    self.stack.pop();
+                }
+                _ => {},
+            }
+        }
+        Ok(())
+    }
+}
+
+/// pretty printer for making multi-line text prettier
+/// uses a String instead of the formatter from before
+struct PrettyPrinter<'a, 'b:'a> {
+    output: &'b mut StdString,
+    stack: Vec<&'a str>,
+}
+
+// #############################################################################
+// Tests
+
+
+#[test]
+fn test_pretty() {
+    // examples of the form (input, expected output). If expected output==None, 
+    // then it == input
+    let mut examples = vec![
+// toml keeps pretty strings
+(r##"[example]
+a_first = "hello world"
+b_second = '''
+this is a little longer
+yay, it looks good!
+'''
+"##, None),
+
+// format with two tables
+(r##"[a_first]
+int = 7
+long = '''
+i like long text
+it is nice
+'''
+
+[b_second]
+int = 10
+text = "this is some text"
+"##, None),
+
+// toml re-orders fields alphabetically
+(r##"[example]
+b_second = ''' woot '''
+a_first = "hello world"
+"##, 
+Some(r##"[example]
+a_first = "hello world"
+b_second = " woot "
+"##)),
+
+// toml reorders tables alphabetically
+("[b]\n[a]\n", Some("[a]\n\n[b]\n")),
+];
+    use Parser;
+
+    for (i, (value, expected)) in examples.drain(..).enumerate() {
+        let expected = match expected {
+            Some(ref r) => r,
+            None => value,
+        };
+        assert_eq!((i, encode_str_pretty(Parser::new(value).parse().unwrap()).unwrap()), 
+                   (i, expected.to_string()));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub use parser::{Parser, ParserError};
 pub use self::encoder::{Encoder, Error, EncoderState, encode, encode_str};
 #[cfg(any(feature = "rustc-serialize", feature = "serde"))]
 pub use self::decoder::{Decoder, DecodeError, DecodeErrorKind, decode, decode_str};
+pub use self::display::encode_str_pretty;
 
 mod parser;
 mod display;


### PR DESCRIPTION
this is my initial working method for making toml strings "prettier."

This method is BAD -- it currently makes a completely separate `Printer` object called `PrettyPrinter` when really only a few lines need to be changed.

The issue I can't get around is that `Printer` has a `Formatter` object attached to it... and I have literally no idea how to get one of those without using the `format!` or related macros and overriding `fmt::Display` (I can't do that because I need to insert the pretty options in somehow!)

Do you know how to get a `Formatter` object so I can use it?

Other tasks:
- move the tests to the `tests` folder

Other comments would be appreciated