### PR TITLE
Added seperate serde functions.

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -83,8 +83,8 @@ pub fn decode<T: ::rustc_serialize::Decodable>(toml: Value) -> Option<T> {
 /// into the type specified. If decoding fails, `None` will be returned. If a
 /// finer-grained error is desired, then it is recommended to use `Decodable`
 /// directly.
-#[cfg(all(not(feature = "rustc-serialize"), feature = "serde"))]
-pub fn decode<T: ::serde::Deserialize>(toml: Value) -> Option<T> {
+#[cfg(feature = "serde")]
+pub fn deserialize<T: ::serde::Deserialize>(toml: Value) -> Option<T> {
     ::serde::Deserialize::deserialize(&mut Decoder::new(toml)).ok()
 }
 
@@ -109,9 +109,9 @@ pub fn decode_str<T: ::rustc_serialize::Decodable>(s: &str) -> Option<T> {
 ///
 /// If more fine-grained errors are desired, these steps should be driven
 /// manually.
-#[cfg(all(not(feature = "rustc-serialize"), feature = "serde"))]
-pub fn decode_str<T: ::serde::Deserialize>(s: &str) -> Option<T> {
-    ::Parser::new(s).parse().and_then(|t| decode(Value::Table(t)))
+#[cfg(feature = "serde")]
+pub fn deserialize_str<T: ::serde::Deserialize>(s: &str) -> Option<T> {
+    ::Parser::new(s).parse().and_then(|t| deserialize(Value::Table(t)))
 }
 
 impl Decoder {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -159,8 +159,8 @@ pub fn encode<T: ::rustc_serialize::Encodable>(t: &T) -> Value {
 ///
 /// This function expects the type given to represent a TOML table in some form.
 /// If encoding encounters an error, then this function will fail the task.
-#[cfg(all(not(feature = "rustc-serialize"), feature = "serde"))]
-pub fn encode<T: ::serde::Serialize>(t: &T) -> Value {
+#[cfg(feature = "serde")]
+pub fn serialize<T: ::serde::Serialize>(t: &T) -> Value {
     let mut e = Encoder::new();
     t.serialize(&mut e).unwrap();
     Value::Table(e.toml)
@@ -179,9 +179,9 @@ pub fn encode_str<T: ::rustc_serialize::Encodable>(t: &T) -> String {
 ///
 /// This function expects the type given to represent a TOML table in some form.
 /// If encoding encounters an error, then this function will fail the task.
-#[cfg(all(not(feature = "rustc-serialize"), feature = "serde"))]
-pub fn encode_str<T: ::serde::Serialize>(t: &T) -> String {
-    encode(t).to_string()
+#[cfg(feature = "serde")]
+pub fn serialize_str<T: ::serde::Serialize>(t: &T) -> String {
+    serialize(t).to_string()
 }
 
 impl fmt::Display for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,19 @@ use std::str::FromStr;
 pub use parser::{Parser, ParserError};
 
 #[cfg(any(feature = "rustc-serialize", feature = "serde"))]
-pub use self::encoder::{Encoder, Error, EncoderState, encode, encode_str};
+pub use self::encoder::{Encoder, Error, EncoderState};
 #[cfg(any(feature = "rustc-serialize", feature = "serde"))]
-pub use self::decoder::{Decoder, DecodeError, DecodeErrorKind, decode, decode_str};
+pub use self::decoder::{Decoder, DecodeError, DecodeErrorKind};
+
+#[cfg(any(feature = "rustc-serialize"))]
+pub use self::encoder::{encode, encode_str};
+#[cfg(any(feature = "rustc-serialize"))]
+pub use self::decoder::{decode, decode_str};
+
+#[cfg(any(feature = "serde"))]
+pub use self::encoder::{serialize, serialize_str};
+#[cfg(any(feature = "serde"))]
+pub use self::decoder::{deserialize, deserialize_str};
 
 mod parser;
 mod display;


### PR DESCRIPTION
Small change to allow the rustc-serialize and serde feature to be used at the same time (with the helper functions). This introduces four new functions `deserialize`, `deserialize_str`, `serialize` and `serialize_str`, which only takes care of serde. While the old functions now only takes care of rustc-serialize. Therefore, this is a breaking change.

Closes #117