### PR TITLE
Fixed sorting of table values

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -367,12 +367,12 @@ impl ser::Serialize for Value {
                 // array-of-tables) as all keys must be emitted first.
                 for (k, v) in t {
                     if !v.is_table() && !v.is_array() ||
-                       (v.as_array().map(|a| a.len() == 0).unwrap_or(false)) {
+                       (v.as_array().map(|a| !a.iter().any(|v| v.is_table())).unwrap_or(false)) {
                         map.serialize_entry(k, v)?;
                     }
                 }
                 for (k, v) in t {
-                    if v.as_array().map(|a| a.len() > 0).unwrap_or(false) {
+                    if v.as_array().map(|a| a.iter().any(|v| v.is_table())).unwrap_or(false) {
                         map.serialize_entry(k, v)?;
                     }
                 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -94,4 +94,10 @@ fn table() {
                 \n\
                 [[test2]]\n\
                 test = [[2, 3], [\"foo\", \"bar\"]]\n");
+    assert_eq!(Table(map! {
+                    "test" => Array(vec![Integer(2)]),
+                    "test2" => Integer(2)
+               }).to_string(),
+               "test = [2]\n\
+                test2 = 2\n");
 }


### PR DESCRIPTION
Fixes writing array after normal values when writing table, that caused this diff after deserialization and serialization to `toml::Value`.
```diff
 [package]
-authors = ["The Gtk-rs Project Developers"]
 build = "build.rs"
 description = "FFI bindings to libpango-1.0"
 homepage = "http://gtk-rs.org/"
-keywords = ["pango", "ffi", "gtk-rs", "gnome"]
 license = "MIT"
 links = "pango"
 name = "pango-sys"
 repository = "https://github.com/gtk-rs/sys"
 version = "0.3.2"
+authors = ["The Gtk-rs Project Developers"]
+keywords = ["pango", "ffi", "gtk-rs", "gnome"]
```