### PR TITLE
Allow extracting the location of the error

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1064,6 +1064,8 @@ impl<'a> Deserializer<'a> {
 
 impl Error {
     /// Produces a (line, column) pair of the position of the error if available
+    ///
+    /// All indexes are 0-based.
     pub fn line_col(&self) -> Option<(usize, usize)> {
         self.inner.line.map(|line| (line, self.inner.col))
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1063,6 +1063,11 @@ impl<'a> Deserializer<'a> {
 }
 
 impl Error {
+    /// Produces a (line, column) pair of the position of the error if available
+    pub fn line_col(&self) -> Option<(usize, usize)> {
+        self.inner.line.map(|line| (line, self.inner.col))
+    }
+
     fn from_kind(kind: ErrorKind) -> Error {
         Error {
             inner: Box::new(ErrorInner {


### PR DESCRIPTION
I'm trying to improve the error reporting in clippy. Since we forward to rustc's error reporting, adding a line + col info to the error would allow rustc to actually hilight the error through the regular mechanisms instead of us producing a "help: some error at file:line" through the `Display` impl of `Error`