### PR TITLE
add example for from_str

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -33,6 +33,37 @@ pub fn from_slice<'de, T>(bytes: &'de [u8]) -> Result<T, Error>
 ///
 /// This function will attempt to interpret `s` as a TOML document and
 /// deserialize `T` from the document.
+///
+/// # Examples
+///
+/// ```no_run
+/// #[macro_use]
+/// extern crate serde_derive;
+/// extern crate toml;
+///
+/// #[derive(Deserialize)]
+/// struct Config {
+///     title: String,
+///     owner: Owner,
+/// }
+///
+/// #[derive(Deserialize)]
+/// struct Owner {
+///     name: String,
+/// }
+///
+/// fn main() {
+///     let config: Config = toml::from_str(r#"
+///         title = 'TOML Example'
+///
+///         [owner]
+///         name = 'Lisa'
+///     "#).unwrap();
+///
+///     assert_eq!(config.title, "TOML Example");
+///     assert_eq!(config.owner.name, "Lisa");
+/// }
+/// ```
 pub fn from_str<'de, T>(s: &'de str) -> Result<T, Error>
     where T: de::Deserialize<'de>,
 {

--- a/src/de.rs
+++ b/src/de.rs
@@ -36,7 +36,7 @@ pub fn from_slice<'de, T>(bytes: &'de [u8]) -> Result<T, Error>
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// #[macro_use]
 /// extern crate serde_derive;
 /// extern crate toml;


### PR DESCRIPTION
First step in order to fix https://github.com/alexcrichton/toml-rs/issues/171: add an example for `toml::de::from_str`

The TOML string used in this example is inspired by the example given on the official TOML repo: https://github.com/toml-lang/toml and code itself is inspired by the example from the index page of this crate: https://docs.rs/toml/0.4.0/toml/index.html#deserialization-and-serialization. I tried to make it a bit shorter and a bit different (in comparison with the index page), maybe I should have only copy/pasted [it](https://docs.rs/toml/0.4.0/toml/index.html#deserialization-and-serialization) (but I think user would prefer different examples across pages). 

The "name" in TOML is an arbitrary choice (not really, in fact it's the name of my daughter, since the original TOML example uses the name of its creator) I can change it if required.