### PR TITLE
Better invalid number handling

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -893,6 +893,12 @@ impl<'a> Deserializer<'a> {
         }
         number.parse().map_err(|_e| {
             self.error(start, ErrorKind::NumberInvalid)
+        }).and_then(|n: f64| {
+            if n.is_finite() {
+                Ok(n)
+            } else {
+                Err(self.error(start, ErrorKind::NumberInvalid))
+            }
         })
     }
 

--- a/tests/invalid-encoder-misc.rs
+++ b/tests/invalid-encoder-misc.rs
@@ -1,0 +1,14 @@
+extern crate toml;
+
+use std::f64;
+
+#[test]
+fn test_invalid_float_encode() {
+    fn bad(value: toml::Value) {
+        assert!(toml::to_string(&value).is_err());
+    }
+
+    bad(toml::Value::Float(f64::INFINITY));
+    bad(toml::Value::Float(f64::NEG_INFINITY));
+    bad(toml::Value::Float(f64::NAN));
+}

--- a/tests/invalid-misc.rs
+++ b/tests/invalid-misc.rs
@@ -10,4 +10,8 @@ fn bad() {
     bad("a = 1__1");
     bad("a = 1_");
     bad("''");
+    bad("a = nan");
+    bad("a = -inf");
+    bad("a = inf");
+    bad("a = 9e99999");
 }


### PR DESCRIPTION
This improves handling of invalid numbers (e.g. `float` or `inf`) by:
- Return an error when deserializing huge numbers like `9e99999` instead of silently deserializing them into `inf`
- Return an error serializing a non-finite number (`nan`, `+inf`, or `-inf`).

Unfortunately, I also ended up adding a variant to the public `toml::se::Error` enum, so this is a breaking change and would need a version bump.

Addresses https://github.com/alexcrichton/toml-rs/issues/181