### PR TITLE
Serialize nested array of tables correctly

### DIFF
--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -61,10 +61,6 @@ macro_rules! error {
     })
 }
 
-macro_rules! decode( ($t:expr) => ({
-    t!($t.try_into())
-}) );
-
 macro_rules! map( ($($k:ident: $v:expr),*) => ({
     let mut _m = BTreeMap::new();
     $(_m.insert(stringify!($k).to_string(), $v);)*

--- a/tests/valid.rs
+++ b/tests/valid.rs
@@ -189,3 +189,7 @@ test!(example4,
 test!(example_bom,
        include_str!("valid/example-bom.toml"),
        include_str!("valid/example.json"));
+
+test!(table_array_nest_no_keys,
+      include_str!("valid/table-array-nest-no-keys.toml"),
+      include_str!("valid/table-array-nest-no-keys.json"));

--- a/tests/valid/table-array-nest-no-keys.json
+++ b/tests/valid/table-array-nest-no-keys.json
@@ -1,0 +1,14 @@
+{
+    "albums": [
+        {
+            "songs": [{}, {}]
+        }
+    ],
+    "artists": [
+        {
+            "home": {
+                "address": {}
+            }
+        }
+    ]
+}

--- a/tests/valid/table-array-nest-no-keys.toml
+++ b/tests/valid/table-array-nest-no-keys.toml
@@ -1,0 +1,6 @@
+[[ albums ]]
+  [[ albums.songs ]]
+  [[ albums.songs ]]
+
+[[ artists ]]
+  [ artists.home.address ]


### PR DESCRIPTION
When serializing nested table like `[a.b.c]`, `toml` will leave out the super-tables if it can. Unfortunately, if one of the super-tables is actually an array of tables (`[[ a ]]`), then leaving out the super-table changes the value being encoded. For example:

```toml
[[ a ]]
[[ a.b ]]
```

which is equivalent to `{"a": [{"b": [{}]}]}` is currently serialized into

```toml
[[ a.b ]]
```

which is equivalent to `{"a": {"b": [{}]}}`, which is not the same.

To fix this, whenever we emit a table header, we check for  `[[ a ]]` parents and emit table headers for them first if necessary.

Closes #180 