### PR TITLE
Implement `IntoDeserializer` for `Value`

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -620,6 +620,14 @@ impl<'de> de::MapAccess<'de> for MapDeserializer {
     }
 }
 
+impl<'de> de::IntoDeserializer<'de, ::de::Error> for Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
 struct Serializer;
 
 impl ser::Serializer for Serializer {


### PR DESCRIPTION
I'm currently in a situation where I have to deserialize a `BTreeMap<String, ::toml::value::Value>` into a `BTreeMap<String, V>` where `V: Deserialize<'de>`.

Currently, the only way I found to do this is as such:

```rust
use serde::de::{self, Deserialize};

let from_map: BTreeMap<String, ::toml::value::Value> = ...;
let to_map: BTreeMap<String, V> =
    Deserialize::deserialize(
        de::value::MapAccessDeserializer::new(
            de::value::MapDeserializer::new(from_map.into_iter())))?;
```

but this requires `Value` to implement `IntoDeserializer`. While there might be an easier/different way to accomplish this deserialization (cc @dtolnay), I guess implementing `IntoDeserializer` doesn't hurt and works for the above example.