### PR TITLE
updated toml version in the docs to 0.4.2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```toml
 //! [package]
 //! name = "toml"
-//! version = "0.2.1"
+//! version = "0.4.2"
 //! authors = ["Alex Crichton <alex@alexcrichton.com>"]
 //!
 //! [dependencies]


### PR DESCRIPTION
Because of the docs, I used `0.2.1` instead of `0.4.2` in my project.

https://docs.rs/toml/0.4.2/toml/