### PR TITLE
close #119: allow "pretty" configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ mod datetime;
 
 pub mod ser;
 #[doc(no_inline)]
-pub use ser::{to_string, to_vec, Serializer};
+pub use ser::{to_string, to_string_pretty, to_vec, Serializer};
 pub mod de;
 #[doc(no_inline)]
 pub use de::{from_slice, from_str, Deserializer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -137,6 +137,21 @@ pub enum Error {
     __Nonexhaustive,
 }
 
+/// If given in `Settings` will result in a "pretty array" with the given settings
+/// TODO: add better docs
+#[derive(Debug, Default, Clone)]
+pub struct ArraySettings {
+    indent: u64,
+}
+
+/// Formatting Settings
+/// TODO: add better docs
+#[derive(Debug, Default, Clone)]
+pub struct Settings {
+    array: Option<ArraySettings>,
+    pretty_string: bool,
+}
+
 /// Serialization implementation for TOML.
 ///
 /// This structure implements serialization support for TOML to serialize an
@@ -149,6 +164,7 @@ pub enum Error {
 pub struct Serializer<'a> {
     dst: &'a mut String,
     state: State<'a>,
+    settings: Settings,
 }
 
 #[derive(Debug, Clone)]
@@ -194,6 +210,7 @@ impl<'a> Serializer<'a> {
         Serializer {
             dst: dst,
             state: State::End,
+            settings: Settings::default(),
         }
     }
 
@@ -591,6 +608,7 @@ impl<'a, 'b> ser::SerializeSeq for SerializeSeq<'a, 'b> {
                 first: &self.first,
                 type_: &self.type_,
             },
+            settings: self.ser.settings.clone(),
         })?;
         self.first.set(false);
         Ok(())
@@ -650,6 +668,7 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
                         first: first,
                         table_emitted: table_emitted,
                     },
+                    settings: ser.settings.clone(),
                 });
                 match res {
                     Ok(()) => first.set(false),
@@ -705,6 +724,7 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
                         first: first,
                         table_emitted: table_emitted,
                     },
+                    settings: ser.settings.clone(),
                 });
                 match res {
                     Ok(()) => first.set(false),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -310,11 +310,11 @@ impl<'a> Serializer<'a> {
     /// ]
     /// ```
     pub fn pretty_array(&mut self, value: bool) -> &mut Self {
-        self.settings.array = Some(if value {
-            ArraySettings::pretty()
+        self.settings.array = if value {
+            Some(ArraySettings::pretty())
         } else {
-            ArraySettings::default()
-        });
+            None
+        };
         self
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -263,14 +263,14 @@ impl<'a> Serializer<'a> {
     ///
     /// Instead of:
     ///
-    /// ```toml,no_run
+    /// ```ignore
     /// single = "no newlines"
     /// text = "\nfoo\nbar\n"
     /// ```
     ///
     /// You will have:
     ///
-    /// ```toml,no_run
+    /// ```ignore
     /// single = "no newlines"
     /// text = '''
     /// foo
@@ -297,13 +297,13 @@ impl<'a> Serializer<'a> {
     ///
     /// Instead of:
     ///
-    /// ```toml,no_run
+    /// ```ignore
     /// array = ["foo", "bar"]
     /// ```
     ///
     /// You will have:
     ///
-    /// ```toml,no_run
+    /// ```ignore
     /// array = [
     ///     "foo",
     ///     "bar",

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -413,7 +413,13 @@ impl<'a> Serializer<'a> {
                 },
                 '\u{c}' => drop(write!(self.dst, "\\f")),
                 '\u{d}' => drop(write!(self.dst, "\\r")),
-                '\u{22}' => drop(write!(self.dst, "\\\"")),
+                '\u{22}' => {
+                    if do_pretty {
+                        drop(write!(self.dst, "\""))
+                    } else {
+                        drop(write!(self.dst, "\\\""))
+                    }
+                },
                 '\u{5c}' => drop(write!(self.dst, "\\\\")),
                 c if c < '\u{1f}' => {
                     drop(write!(self.dst, "\\u{:04X}", ch as u32))

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -142,6 +142,7 @@ pub enum Error {
 #[derive(Debug, Default, Clone)]
 pub struct ArraySettings {
     indent: u64,
+    trailing_comma: bool,
 }
 
 /// Formatting Settings
@@ -224,6 +225,7 @@ impl<'a> Serializer<'a> {
             settings: Settings {
                 array: Some(ArraySettings {
                     indent: 4,
+                    trailing_comma: true,
                 }),
                 pretty_string: true,
             },
@@ -667,10 +669,16 @@ impl<'a, 'b> ser::SerializeSeq for SerializeSeq<'a, 'b> {
         match self.type_.get() {
             Some("table") => return Ok(()),
             Some(_) => {
-                if self.ser.settings.array.is_some() {
-                    self.ser.dst.push_str("\n]");
-                } else {
-                    self.ser.dst.push_str("]");
+                match self.ser.settings.array {
+                    Some(ref a) => {
+                        if a.trailing_comma {
+                            self.ser.dst.push_str(",");
+                        }
+                        self.ser.dst.push_str("\n]");
+                    },
+                    None => {
+                        self.ser.dst.push_str("]");
+                    }
                 }
             }
             None => {

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -3,7 +3,7 @@ extern crate serde;
 
 use serde::ser::Serialize;
 
-const example: &str = "\
+const EXAMPLE: &str = "\
 [example]
 text = '''
 this is the first line
@@ -13,8 +13,8 @@ this is the second line
 
 #[test]
 fn test_pretty() {
-    let value: toml::Value = toml::from_str(example).unwrap();
+    let value: toml::Value = toml::from_str(EXAMPLE).unwrap();
     let mut result = String::with_capacity(128);
     value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
-    assert_eq!(example, &result);
+    assert_eq!(EXAMPLE, &result);
 }

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -1,0 +1,20 @@
+extern crate toml;
+extern crate serde;
+
+use serde::ser::Serialize;
+
+const example: &str = "\
+[example]
+text = '''
+this is the first line
+this is the second line
+'''
+";
+
+#[test]
+fn test_pretty() {
+    let value: toml::Value = toml::from_str(example).unwrap();
+    let mut result = String::with_capacity(128);
+    value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
+    assert_eq!(example, &result);
+}

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -5,6 +5,10 @@ use serde::ser::Serialize;
 
 const EXAMPLE: &str = "\
 [example]
+array = [
+    \"item 1\",
+    \"item 2\",
+]
 text = '''
 this is the first line
 this is the second line
@@ -16,5 +20,7 @@ fn test_pretty() {
     let value: toml::Value = toml::from_str(EXAMPLE).unwrap();
     let mut result = String::with_capacity(128);
     value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
+    println!("example:\n{}", EXAMPLE);
+    println!("result:\n{}", result);
     assert_eq!(EXAMPLE, &result);
 }

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -3,7 +3,7 @@ extern crate serde;
 
 use serde::ser::Serialize;
 
-const EXAMPLE: &str = "\
+const EXAMPLE: &'static str = "\
 [example]
 array = [
     \"item 1\",

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -3,12 +3,14 @@ extern crate serde;
 
 use serde::ser::Serialize;
 
-const EXAMPLE: &'static str = "\
+const PRETTY_STD: &'static str = "\
 [example]
 array = [
     \"item 1\",
     \"item 2\",
 ]
+empty = []
+oneline = \"this has no newlines.\"
 text = '''
 this is the first line
 this is the second line
@@ -16,11 +18,116 @@ this is the second line
 ";
 
 #[test]
-fn test_pretty() {
-    let value: toml::Value = toml::from_str(EXAMPLE).unwrap();
+fn test_pretty_std() {
+    let toml = PRETTY_STD;
+    let value: toml::Value = toml::from_str(toml).unwrap();
     let mut result = String::with_capacity(128);
     value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
-    println!("example:\n{}", EXAMPLE);
-    println!("result:\n{}", result);
-    assert_eq!(EXAMPLE, &result);
+    println!("EXPECTED:\n{}", toml);
+    println!("\nRESULT:\n{}", result);
+    assert_eq!(toml, &result);
+}
+
+
+const PRETTY_INDENT_2: &'static str = "\
+[example]
+array = [
+  \"item 1\",
+  \"item 2\",
+]
+empty = []
+oneline = \"this has no newlines.\"
+text = '''
+this is the first line
+this is the second line
+'''
+";
+
+#[test]
+fn test_pretty_indent_2() {
+    let toml = PRETTY_INDENT_2;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    {
+        let mut serializer = toml::Serializer::pretty(&mut result);
+        serializer.pretty_array_indent(2);
+        value.serialize(&mut serializer).unwrap();
+    }
+    assert_eq!(toml, &result);
+}
+
+const PRETTY_INDENT_2_OTHER: &'static str = "\
+[example]
+array = [
+  \"item 1\",
+  \"item 2\",
+]
+empty = []
+oneline = \"this has no newlines.\"
+text = \"\\nthis is the first line\\nthis is the second line\\n\"
+";
+
+
+#[test]
+/// Test pretty indent when gotten the other way
+fn test_pretty_indent_2_other() {
+    let toml = PRETTY_INDENT_2_OTHER;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    {
+        let mut serializer = toml::Serializer::new(&mut result);
+        serializer.pretty_array_indent(2);
+        value.serialize(&mut serializer).unwrap();
+    }
+    assert_eq!(toml, &result);
+}
+
+
+const PRETTY_ARRAY_NO_COMMA: &'static str = "\
+[example]
+array = [
+    \"item 1\",
+    \"item 2\"
+]
+empty = []
+oneline = \"this has no newlines.\"
+text = \"\\nthis is the first line\\nthis is the second line\\n\"
+";
+#[test]
+/// Test pretty indent when gotten the other way
+fn test_pretty_indent_array_no_comma() {
+    let toml = PRETTY_ARRAY_NO_COMMA;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    {
+        let mut serializer = toml::Serializer::new(&mut result);
+        serializer.pretty_array_trailing_comma(false);
+        value.serialize(&mut serializer).unwrap();
+    }
+    assert_eq!(toml, &result);
+}
+
+
+const PRETTY_NO_STRING: &'static str = "\
+[example]
+array = [
+    \"item 1\",
+    \"item 2\",
+]
+empty = []
+oneline = \"this has no newlines.\"
+text = \"\\nthis is the first line\\nthis is the second line\\n\"
+";
+#[test]
+/// Test pretty indent when gotten the other way
+fn test_pretty_no_string() {
+    let toml = PRETTY_NO_STRING;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    {
+        let mut serializer = toml::Serializer::pretty(&mut result);
+        serializer.pretty_string(false);
+        value.serialize(&mut serializer).unwrap();
+    }
+    assert_eq!(toml, &result);
 }

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -3,6 +3,41 @@ extern crate serde;
 
 use serde::ser::Serialize;
 
+const NO_PRETTY: &'static str = "\
+[example]
+array = [\"item 1\", \"item 2\"]
+empty = []
+oneline = \"this has no newlines.\"
+text = \"\\nthis is the first line\\nthis is the second line\\n\"
+";
+
+#[test]
+fn no_pretty() {
+    let toml = NO_PRETTY;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    value.serialize(&mut toml::Serializer::new(&mut result)).unwrap();
+    println!("EXPECTED:\n{}", toml);
+    println!("\nRESULT:\n{}", result);
+    assert_eq!(toml, &result);
+}
+
+#[test]
+fn disable_pretty() {
+    let toml = NO_PRETTY;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    {
+        let mut serializer = toml::Serializer::pretty(&mut result);
+        serializer.pretty_string(false);
+        serializer.pretty_array(false);
+        value.serialize(&mut serializer).unwrap();
+    }
+    println!("EXPECTED:\n{}", toml);
+    println!("\nRESULT:\n{}", result);
+    assert_eq!(toml, &result);
+}
+
 const PRETTY_STD: &'static str = "\
 [example]
 array = [
@@ -18,7 +53,7 @@ this is the second line
 ";
 
 #[test]
-fn test_pretty_std() {
+fn pretty_std() {
     let toml = PRETTY_STD;
     let value: toml::Value = toml::from_str(toml).unwrap();
     let mut result = String::with_capacity(128);
@@ -44,7 +79,7 @@ this is the second line
 ";
 
 #[test]
-fn test_pretty_indent_2() {
+fn pretty_indent_2() {
     let toml = PRETTY_INDENT_2;
     let value: toml::Value = toml::from_str(toml).unwrap();
     let mut result = String::with_capacity(128);
@@ -70,7 +105,7 @@ text = \"\\nthis is the first line\\nthis is the second line\\n\"
 
 #[test]
 /// Test pretty indent when gotten the other way
-fn test_pretty_indent_2_other() {
+fn pretty_indent_2_other() {
     let toml = PRETTY_INDENT_2_OTHER;
     let value: toml::Value = toml::from_str(toml).unwrap();
     let mut result = String::with_capacity(128);
@@ -95,7 +130,7 @@ text = \"\\nthis is the first line\\nthis is the second line\\n\"
 ";
 #[test]
 /// Test pretty indent when gotten the other way
-fn test_pretty_indent_array_no_comma() {
+fn pretty_indent_array_no_comma() {
     let toml = PRETTY_ARRAY_NO_COMMA;
     let value: toml::Value = toml::from_str(toml).unwrap();
     let mut result = String::with_capacity(128);
@@ -120,7 +155,7 @@ text = \"\\nthis is the first line\\nthis is the second line\\n\"
 ";
 #[test]
 /// Test pretty indent when gotten the other way
-fn test_pretty_no_string() {
+fn pretty_no_string() {
     let toml = PRETTY_NO_STRING;
     let value: toml::Value = toml::from_str(toml).unwrap();
     let mut result = String::with_capacity(128);


### PR DESCRIPTION
This is an MVP of the "pretty" configuration impelmentation. There are some things I would still like to do (like avoid having to clone `Settings`) and there are still a bunch of tests that need to be added but this seems to work 🎉 🎉 

This is necessary for:
- vitiral/artifact#87
- vitiral/artifact#152

I would particularily like feedback from @alexcrichton on:
- Is it okay to have a `Settings` struct instead of a `Formatter` trait, as suggested by @dtolnay. @dtolnay what do you think about this? I see the trait as probably "higher speed" but I don't think that's as much a requirement for toml as it is for json.
- What should the name be? Is `toml::ser::Settings` good?

Improvements needed:
- The `Serializer::pretty` is [mimicking serde_json's][1] implementation, but we should make `pretty` accept a `Settings` struct
- We should add a `to_string_pretty(dst: &mut W, settings: Settings)` method

[1]: https://docs.serde.rs/serde_json/struct.Serializer.html#method.pretty