### PR TITLE
demonstrate tripple quote problem

### DIFF
--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -166,3 +166,22 @@ fn pretty_no_string() {
     }
     assert_eq!(toml, &result);
 }
+
+const PRETTY_TRICKY: &'static str = r"[example]
+text = '''
+this is the first line
+This has a ''\' in it for no reason
+this is the third line
+'''
+";
+
+#[test]
+fn pretty_tricky() {
+    let toml = PRETTY_TRICKY;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
+    println!("EXPECTED:\n{}", toml);
+    println!("\nRESULT:\n{}", result);
+    assert_eq!(toml, &result);
+}

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -41,11 +41,12 @@ fn disable_pretty() {
 const PRETTY_STD: &'static str = "\
 [example]
 array = [
-    \"item 1\",
-    \"item 2\",
+    'item 1',
+    'item 2',
 ]
 empty = []
-oneline = \"this has no newlines.\"
+one = ['one']
+oneline = 'this has no newlines.'
 text = '''
 this is the first line
 this is the second line
@@ -67,15 +68,21 @@ fn pretty_std() {
 const PRETTY_INDENT_2: &'static str = "\
 [example]
 array = [
-  \"item 1\",
-  \"item 2\",
+  'item 1',
+  'item 2',
 ]
 empty = []
-oneline = \"this has no newlines.\"
+one = ['one']
+oneline = 'this has no newlines.'
 text = '''
 this is the first line
 this is the second line
 '''
+three = [
+  'one',
+  'two',
+  'three',
+]
 ";
 
 #[test]
@@ -88,6 +95,7 @@ fn pretty_indent_2() {
         serializer.pretty_array_indent(2);
         value.serialize(&mut serializer).unwrap();
     }
+    println!(">> Result:\n{}", result);
     assert_eq!(toml, &result);
 }
 
@@ -168,6 +176,7 @@ fn pretty_no_string() {
 }
 
 const PRETTY_TRICKY: &'static str = r"[example]
+single = '''this is a single line but has '' for no reason'''
 text = '''
 this is the first line
 This has a ''\' in it for no reason

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -175,14 +175,32 @@ fn pretty_no_string() {
     assert_eq!(toml, &result);
 }
 
-const PRETTY_TRICKY: &'static str = r"[example]
-single = '''this is a single line but has '' for no reason'''
-text = '''
-this is the first line
-This has a ''\' in it for no reason
-this is the third line
+const PRETTY_TRICKY: &'static str = r##"[example]
+f = "\f"
+glass = '''
+Nothing too unusual, except that I can eat glass in:
+- Greek: Μπορώ να φάω σπασμένα γυαλιά χωρίς να πάθω τίποτα. 
+- Polish: Mogę jeść szkło, i mi nie szkodzi. 
+- Hindi: मैं काँच खा सकता हूँ, मुझे उस से कोई पीडा नहीं होती. 
+- Japanese: 私はガラスを食べられます。それは私を傷つけません。 
 '''
-";
+r = "\r"
+r_newline = """
+\r
+"""
+single = '''this is a single line but has '' cuz it's tricky'''
+single_tricky = "single line with ''' in it"
+tabs = '''
+this is pretty standard
+	except for some 	tabs right here
+'''
+text = """
+this is the first line.
+This has a ''' in it and \"\"\" cuz it's tricky yo
+Also ' and \" because why not
+this is the third line
+"""
+"##;
 
 #[test]
 fn pretty_tricky() {


### PR DESCRIPTION
This is to demonstrate the tripple quote problem I theorized: that if there are `'''` in a pretty string there will be issues. However, the issue I hit was not as expected.

The written test prints the following:
```
EXPECTED:                                              
[example]                                            
text = '''                                          
this is the first line                                                                                   
This has a ''\' in it for no reason                                                                      
this is the third line                               
'''                                                 


RESULT:                                                                                                  
[example]                                           
text = '''                                                                                               
this is the first line                              
This has a ''\\' in it for no reason                
this is the third line                              
''' 
```

It seems that the round trip is doubling the number of `\` it finds?