### PR TITLE
related to #202: move 'pretty' behind a beta feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo test
+  - cargo test --features beta
   - rustdoc --test README.md -L target
   - cargo doc --no-deps
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ travis-ci = { repository = "alexcrichton/toml-rs" }
 [dependencies]
 serde = "1.0"
 
+[features]
+default = []
+beta = []
+
 [dev-dependencies]
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,11 @@ mod datetime;
 
 pub mod ser;
 #[doc(no_inline)]
-pub use ser::{to_string, to_string_pretty, to_vec, Serializer};
+pub use ser::{to_string, to_vec, Serializer};
+#[cfg(feature = "beta")]
+#[doc(no_inline)]
+pub use ser::to_string_pretty;
+
 pub mod de;
 #[doc(no_inline)]
 pub use de::{from_slice, from_str, Deserializer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -97,6 +97,7 @@ pub fn to_string<T: ?Sized>(value: &T) -> Result<String, Error>
 ///
 /// This is identical to `to_string` except the output string has a more
 /// "pretty" output. See `Serializer::pretty` for more details.
+#[cfg(feature = "beta")]
 pub fn to_string_pretty<T: ?Sized>(value: &T) -> Result<String, Error>
     where T: ser::Serialize,
 {
@@ -157,6 +158,7 @@ struct ArraySettings {
     trailing_comma: bool,
 }
 
+#[cfg(feature = "beta")]
 impl ArraySettings {
     fn pretty() -> ArraySettings {
         ArraySettings {
@@ -244,6 +246,7 @@ impl<'a> Serializer<'a> {
     ///   `Serializer::pretty_string`
     /// - pretty arrays: each item in arrays will be on a newline, have an indentation of 4 and
     ///   have a trailing comma. See `Serializer::pretty_array`
+    #[cfg(feature = "beta")]
     pub fn pretty(dst: &'a mut String) -> Serializer<'a> {
         Serializer {
             dst: dst,
@@ -277,6 +280,7 @@ impl<'a> Serializer<'a> {
     /// bar
     /// '''
     /// ```
+    #[cfg(feature = "beta")]
     pub fn pretty_string(&mut self, value: bool) -> &mut Self {
         self.settings.pretty_string = value;
         self
@@ -309,6 +313,7 @@ impl<'a> Serializer<'a> {
     ///     "bar",
     /// ]
     /// ```
+    #[cfg(feature = "beta")]
     pub fn pretty_array(&mut self, value: bool) -> &mut Self {
         self.settings.array = if value {
             Some(ArraySettings::pretty())
@@ -321,6 +326,7 @@ impl<'a> Serializer<'a> {
     /// Set the indent for pretty arrays
     ///
     /// See `Serializer::pretty_array` for more details.
+    #[cfg(feature = "beta")]
     pub fn pretty_array_indent(&mut self, value: usize) -> &mut Self {
         let use_default = if let &mut Some(ref mut a) = &mut self.settings.array {
             a.indent = value;
@@ -340,6 +346,7 @@ impl<'a> Serializer<'a> {
     /// Specify whether to use a trailing comma when serializing pretty arrays
     ///
     /// See `Serializer::pretty_array` for more details.
+    #[cfg(feature = "beta")]
     pub fn pretty_array_trailing_comma(&mut self, value: bool) -> &mut Self {
         let use_default = if let &mut Some(ref mut a) = &mut self.settings.array {
             a.trailing_comma = value;

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -1,9 +1,12 @@
 extern crate toml;
 extern crate serde;
 
-use serde::ser::Serialize;
+#[cfg(feature = "beta")]
+mod test_pretty {
+    use serde::ser::Serialize;
+    use toml;
 
-const NO_PRETTY: &'static str = "\
+    const NO_PRETTY: &'static str = "\
 [example]
 array = [\"item 1\", \"item 2\"]
 empty = []
@@ -11,34 +14,34 @@ oneline = \"this has no newlines.\"
 text = \"\\nthis is the first line\\nthis is the second line\\n\"
 ";
 
-#[test]
-fn no_pretty() {
-    let toml = NO_PRETTY;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    value.serialize(&mut toml::Serializer::new(&mut result)).unwrap();
-    println!("EXPECTED:\n{}", toml);
-    println!("\nRESULT:\n{}", result);
-    assert_eq!(toml, &result);
-}
-
-#[test]
-fn disable_pretty() {
-    let toml = NO_PRETTY;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    {
-        let mut serializer = toml::Serializer::pretty(&mut result);
-        serializer.pretty_string(false);
-        serializer.pretty_array(false);
-        value.serialize(&mut serializer).unwrap();
+    #[test]
+    fn no_pretty() {
+        let toml = NO_PRETTY;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        value.serialize(&mut toml::Serializer::new(&mut result)).unwrap();
+        println!("EXPECTED:\n{}", toml);
+        println!("\nRESULT:\n{}", result);
+        assert_eq!(toml, &result);
     }
-    println!("EXPECTED:\n{}", toml);
-    println!("\nRESULT:\n{}", result);
-    assert_eq!(toml, &result);
-}
 
-const PRETTY_STD: &'static str = "\
+    #[test]
+    fn disable_pretty() {
+        let toml = NO_PRETTY;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        {
+            let mut serializer = toml::Serializer::pretty(&mut result);
+            serializer.pretty_string(false);
+            serializer.pretty_array(false);
+            value.serialize(&mut serializer).unwrap();
+        }
+        println!("EXPECTED:\n{}", toml);
+        println!("\nRESULT:\n{}", result);
+        assert_eq!(toml, &result);
+    }
+
+    const PRETTY_STD: &'static str = "\
 [example]
 array = [
     \"item 1\",
@@ -52,19 +55,19 @@ this is the second line
 '''
 ";
 
-#[test]
-fn pretty_std() {
-    let toml = PRETTY_STD;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
-    println!("EXPECTED:\n{}", toml);
-    println!("\nRESULT:\n{}", result);
-    assert_eq!(toml, &result);
-}
+    #[test]
+    fn pretty_std() {
+        let toml = PRETTY_STD;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
+        println!("EXPECTED:\n{}", toml);
+        println!("\nRESULT:\n{}", result);
+        assert_eq!(toml, &result);
+    }
 
 
-const PRETTY_INDENT_2: &'static str = "\
+    const PRETTY_INDENT_2: &'static str = "\
 [example]
 array = [
   \"item 1\",
@@ -78,20 +81,20 @@ this is the second line
 '''
 ";
 
-#[test]
-fn pretty_indent_2() {
-    let toml = PRETTY_INDENT_2;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    {
-        let mut serializer = toml::Serializer::pretty(&mut result);
-        serializer.pretty_array_indent(2);
-        value.serialize(&mut serializer).unwrap();
+    #[test]
+    fn pretty_indent_2() {
+        let toml = PRETTY_INDENT_2;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        {
+            let mut serializer = toml::Serializer::pretty(&mut result);
+            serializer.pretty_array_indent(2);
+            value.serialize(&mut serializer).unwrap();
+        }
+        assert_eq!(toml, &result);
     }
-    assert_eq!(toml, &result);
-}
 
-const PRETTY_INDENT_2_OTHER: &'static str = "\
+    const PRETTY_INDENT_2_OTHER: &'static str = "\
 [example]
 array = [
   \"item 1\",
@@ -104,21 +107,21 @@ text = \"\\nthis is the first line\\nthis is the second line\\n\"
 
 
 #[test]
-/// Test pretty indent when gotten the other way
-fn pretty_indent_2_other() {
-    let toml = PRETTY_INDENT_2_OTHER;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    {
-        let mut serializer = toml::Serializer::new(&mut result);
-        serializer.pretty_array_indent(2);
-        value.serialize(&mut serializer).unwrap();
+    /// Test pretty indent when gotten the other way
+    fn pretty_indent_2_other() {
+        let toml = PRETTY_INDENT_2_OTHER;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        {
+            let mut serializer = toml::Serializer::new(&mut result);
+            serializer.pretty_array_indent(2);
+            value.serialize(&mut serializer).unwrap();
+        }
+        assert_eq!(toml, &result);
     }
-    assert_eq!(toml, &result);
-}
 
 
-const PRETTY_ARRAY_NO_COMMA: &'static str = "\
+    const PRETTY_ARRAY_NO_COMMA: &'static str = "\
 [example]
 array = [
     \"item 1\",
@@ -128,22 +131,23 @@ empty = []
 oneline = \"this has no newlines.\"
 text = \"\\nthis is the first line\\nthis is the second line\\n\"
 ";
-#[test]
-/// Test pretty indent when gotten the other way
-fn pretty_indent_array_no_comma() {
-    let toml = PRETTY_ARRAY_NO_COMMA;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    {
-        let mut serializer = toml::Serializer::new(&mut result);
-        serializer.pretty_array_trailing_comma(false);
-        value.serialize(&mut serializer).unwrap();
+
+    #[test]
+    /// Test pretty indent when gotten the other way
+    fn pretty_indent_array_no_comma() {
+        let toml = PRETTY_ARRAY_NO_COMMA;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        {
+            let mut serializer = toml::Serializer::new(&mut result);
+            serializer.pretty_array_trailing_comma(false);
+            value.serialize(&mut serializer).unwrap();
+        }
+        assert_eq!(toml, &result);
     }
-    assert_eq!(toml, &result);
-}
 
 
-const PRETTY_NO_STRING: &'static str = "\
+    const PRETTY_NO_STRING: &'static str = "\
 [example]
 array = [
     \"item 1\",
@@ -153,16 +157,18 @@ empty = []
 oneline = \"this has no newlines.\"
 text = \"\\nthis is the first line\\nthis is the second line\\n\"
 ";
-#[test]
-/// Test pretty indent when gotten the other way
-fn pretty_no_string() {
-    let toml = PRETTY_NO_STRING;
-    let value: toml::Value = toml::from_str(toml).unwrap();
-    let mut result = String::with_capacity(128);
-    {
-        let mut serializer = toml::Serializer::pretty(&mut result);
-        serializer.pretty_string(false);
-        value.serialize(&mut serializer).unwrap();
+
+    #[test]
+    /// Test pretty indent when gotten the other way
+    fn pretty_no_string() {
+        let toml = PRETTY_NO_STRING;
+        let value: toml::Value = toml::from_str(toml).unwrap();
+        let mut result = String::with_capacity(128);
+        {
+            let mut serializer = toml::Serializer::pretty(&mut result);
+            serializer.pretty_string(false);
+            value.serialize(&mut serializer).unwrap();
+        }
+        assert_eq!(toml, &result);
     }
-    assert_eq!(toml, &result);
 }


### PR DESCRIPTION
As suggested in #202 we should implement a `beta` feature flag until pretty formatting is more stabilized. We need to decide between `"""` and `'''` and if we choose `'''` (the current) we need several tests and bufixes