### PR TITLE
add spaces between array items and test for them

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -628,12 +628,25 @@ impl<'a> Serializer<'a> {
         }
 
         match *state {
-            State::Table { first, .. } |
-            State::Array { parent: &State::Table { first, .. }, .. } => {
+            State::Table { first, .. } => {
                 if !first.get() {
-                    self.dst.push_str("\n");
+                    // Newline if we are a table that is not the first
+                    // table in the document.
+                    self.dst.push('\n');
                 }
-            }
+            },
+            State::Array { parent, first, .. } => {
+                if !first.get() {
+                    // Always newline if we are not the first item in the
+                    // table-array
+                    self.dst.push('\n');
+                } else if let State::Table { first, .. } = *parent {
+                    if !first.get() {
+                        // Newline if we are not the first item in the document 
+                        self.dst.push('\n');
+                    }
+                }
+            },
             _ => {}
         }
         self.dst.push_str("[");

--- a/tests/pretty.rs
+++ b/tests/pretty.rs
@@ -212,3 +212,51 @@ fn pretty_tricky() {
     println!("\nRESULT:\n{}", result);
     assert_eq!(toml, &result);
 }
+
+const PRETTY_TABLE_ARRAY: &'static str = r##"[[array]]
+key = 'foo'
+
+[[array]]
+key = 'bar'
+
+[abc]
+doc = 'this is a table'
+
+[example]
+single = 'this is a single line string'
+"##;
+
+#[test]
+fn pretty_table_array() {
+    let toml = PRETTY_TABLE_ARRAY;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    value.serialize(&mut toml::Serializer::pretty(&mut result)).unwrap();
+    println!("EXPECTED:\n{}", toml);
+    println!("\nRESULT:\n{}", result);
+    assert_eq!(toml, &result);
+}
+
+const TABLE_ARRAY: &'static str = r##"[[array]]
+key = "foo"
+
+[[array]]
+key = "bar"
+
+[abc]
+doc = "this is a table"
+
+[example]
+single = "this is a single line string"
+"##;
+
+#[test]
+fn table_array() {
+    let toml = TABLE_ARRAY;
+    let value: toml::Value = toml::from_str(toml).unwrap();
+    let mut result = String::with_capacity(128);
+    value.serialize(&mut toml::Serializer::new(&mut result)).unwrap();
+    println!("EXPECTED:\n{}", toml);
+    println!("\nRESULT:\n{}", result);
+    assert_eq!(toml, &result);
+}


### PR DESCRIPTION
@killercup noticed in killercup/cargo-edit#163

> This format is pretty (😄), except for the missing newlines around these sections

"these sections" being array items. I actually think that this was probably broken before my changes (but maybe not). Never-the-less this PR fixes the issue and adds spaces around array-table items.

Before:
```
[[array]]
key = "foo"
[[array]]
key = "bar"

[table]
key = "baz"
```

After:
```
[[array]]
key = "foo"

[[array]]
key = "bar"

[table]
key = "baz"
```
