### PR TITLE
[WIP] Nested structs fail to serialize with ValueAfterTable error because struct properties are not ordered

### DIFF
--- a/test-suite/tests/tables-last.rs
+++ b/test-suite/tests/tables-last.rs
@@ -28,3 +28,27 @@ fn always_works() {
 
     toml::to_string(&a).unwrap();
 }
+
+#[derive(Serialize)]
+struct B {
+    property: bool,
+}
+
+#[derive(Serialize)]
+struct C {
+    b: B,
+    // struct B will be serialized as a table, so this property must not appear
+    // after it and must be serialized before b.
+    property2: bool,
+}
+
+// Make sure that serializing with nested structs and property ordering always
+// works.
+#[test]
+fn nested_struct_tables() {
+    let c = C {
+        property2: false,
+        b: B { property: true },
+    };
+    toml::to_string(&c).unwrap();
+}


### PR DESCRIPTION
Problem: if you use nested structs and you specify primitive struct properties after the nested struct then serialization fails.

Attached is a test case that demonstrates the problem.

Not sure how and where to solve this exactly, maybe you can give me some pointers where to start? I think we need to order struct properties before handing them down to the next serialization step, so that primitive properties always come first.

cc @dtolnay who might also have an idea about this :-)