### PR TITLE
adding function to insert new values to toml table

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -204,6 +204,14 @@ impl Value {
             Value::Table(..) => "table",
         }
     }
+
+    /// Adding new Value to a Table. Returns `None` when fail (Value is not a table);
+    pub fn insert(&mut self, key: &str, value: Value) -> Option<()>
+    { 
+        let table = self.as_table_mut()?;
+        table.insert(key.to_string(), value);
+        Some(())
+    }
 }
 
 impl<I> ops::Index<I> for Value where I: Index {

--- a/test-suite/tests/invalid-misc.rs
+++ b/test-suite/tests/invalid-misc.rs
@@ -1,4 +1,5 @@
 extern crate toml;
+use toml::Value;
 
 #[test]
 fn bad() {
@@ -14,4 +15,23 @@ fn bad() {
     bad("a = -inf");
     bad("a = inf");
     bad("a = 9e99999");
+}
+
+#[test]
+fn inserting_value() {
+
+    let insert_error = "failed to insert value";
+    let cast_error = "failed to cast value";
+
+    let mut some_value: Value = toml::from_str("a=1").expect("failed to create Value");
+    some_value
+        .insert("b", Value::Integer(2))
+        .expect(insert_error);
+    some_value
+        .insert("c", Value::Integer(3))
+        .expect(insert_error);
+
+    assert_eq!(some_value["a"].as_integer().expect(cast_error), 1);
+    assert_eq!(some_value["b"].as_integer().expect(cast_error), 2);
+    assert_eq!(some_value["c"].as_integer().expect(cast_error), 3);
 }


### PR DESCRIPTION
I implement inserting new values directly into the Value.
I wrote about it in an Issue here:
https://github.com/alexcrichton/toml-rs/issues/231

We can already quickly get values from Value with index access, but inserting the new Value is kind of clunky, so I added the helper function directly inside the Value.