### PR TITLE
Support spans when deserializing serde structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "alexcrichton/toml-rs" }
 
 [dependencies]
 serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
-serde_derive = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,5 @@ travis-ci = { repository = "alexcrichton/toml-rs" }
 serde = "1.0"
 
 [dev-dependencies]
+serde_derive = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ travis-ci = { repository = "alexcrichton/toml-rs" }
 
 [dependencies]
 serde = "1.0"
-serde_derive = "1.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -40,8 +40,8 @@ pub struct DatetimeParseError {
 //
 // In general the TOML encoder/decoder will catch this and not literally emit
 // these strings but rather emit datetimes as they're intended.
-pub const SERDE_STRUCT_FIELD_NAME: &'static str = "$__toml_private_datetime";
-pub const SERDE_STRUCT_NAME: &'static str = "$__toml_private_Datetime";
+pub const FIELD: &'static str = "$__toml_private_datetime";
+pub const NAME: &'static str = "$__toml_private_Datetime";
 
 #[derive(PartialEq, Clone)]
 struct Date {
@@ -311,8 +311,8 @@ impl ser::Serialize for Datetime {
     {
         use serde::ser::SerializeStruct;
 
-        let mut s = serializer.serialize_struct(SERDE_STRUCT_NAME, 1)?;
-        s.serialize_field(SERDE_STRUCT_FIELD_NAME, &self.to_string())?;
+        let mut s = serializer.serialize_struct(NAME, 1)?;
+        s.serialize_field(FIELD, &self.to_string())?;
         s.end()
     }
 }
@@ -343,10 +343,8 @@ impl<'de> de::Deserialize<'de> for Datetime {
             }
         }
 
-        static FIELDS: [&'static str; 1] = [SERDE_STRUCT_FIELD_NAME];
-        deserializer.deserialize_struct(SERDE_STRUCT_NAME,
-                                        &FIELDS,
-                                        DatetimeVisitor)
+        static FIELDS: [&'static str; 1] = [FIELD];
+        deserializer.deserialize_struct(NAME, &FIELDS, DatetimeVisitor)
     }
 }
 
@@ -368,7 +366,7 @@ impl<'de> de::Deserialize<'de> for DatetimeKey {
             fn visit_str<E>(self, s: &str) -> Result<(), E>
                 where E: de::Error
             {
-                if s == SERDE_STRUCT_FIELD_NAME {
+                if s == FIELD {
                     Ok(())
                 } else {
                     Err(de::Error::custom("expected field with custom name"))

--- a/src/de.rs
+++ b/src/de.rs
@@ -12,6 +12,7 @@ use std::vec;
 
 use serde::de;
 use serde::de::IntoDeserializer;
+use serde::de::value::BorrowedStrDeserializer;
 
 use tokens::{Tokenizer, Token, Error as TokenError, Span};
 use datetime;
@@ -620,11 +621,11 @@ impl<'de> de::MapAccess<'de> for SpannedDeserializer<'de> {
         K: de::DeserializeSeed<'de>,
     {
         if self.start.is_some() {
-            seed.deserialize(spanned::START.into_deserializer()).map(Some)
+            seed.deserialize(BorrowedStrDeserializer::new(spanned::START)).map(Some)
         } else if self.end.is_some() {
-            seed.deserialize(spanned::END.into_deserializer()).map(Some)
+            seed.deserialize(BorrowedStrDeserializer::new(spanned::END)).map(Some)
         } else if self.value.is_some() {
-            seed.deserialize(spanned::VALUE.into_deserializer()).map(Some)
+            seed.deserialize(BorrowedStrDeserializer::new(spanned::VALUE)).map(Some)
         } else {
             Ok(None)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,3 +173,4 @@ mod tokens;
 pub mod macros;
 
 pub mod spanned;
+pub use spanned::Spanned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,8 +153,6 @@
 
 #[macro_use]
 extern crate serde;
-#[macro_use]
-extern crate serde_derive;
 
 pub mod value;
 #[doc(no_inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,6 @@ mod tokens;
 #[doc(hidden)]
 pub mod macros;
 
-pub mod spanned;
+mod spanned;
 #[doc(no_inline)]
 pub use spanned::Spanned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,8 @@
 
 #[macro_use]
 extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 
 pub mod value;
 #[doc(no_inline)]
@@ -169,3 +171,5 @@ mod tokens;
 
 #[doc(hidden)]
 pub mod macros;
+
+pub mod spanned;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,4 +171,5 @@ mod tokens;
 pub mod macros;
 
 pub mod spanned;
+#[doc(no_inline)]
 pub use spanned::Spanned;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -33,7 +33,7 @@ use std::marker;
 use std::rc::Rc;
 
 use serde::ser;
-use datetime::{SERDE_STRUCT_FIELD_NAME, SERDE_STRUCT_NAME};
+use datetime;
 
 /// Serialize the given data structure as a TOML byte vector.
 ///
@@ -924,7 +924,7 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
 
     fn serialize_struct(self, name: &'static str, _len: usize)
                         -> Result<Self::SerializeStruct, Self::Error> {
-        if name == SERDE_STRUCT_NAME {
+        if name == datetime::NAME {
             self.array_type("datetime")?;
             Ok(SerializeTable::Datetime(self))
         } else {
@@ -1071,7 +1071,7 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
     {
         match *self {
             SerializeTable::Datetime(ref mut ser) => {
-                if key == SERDE_STRUCT_FIELD_NAME {
+                if key == datetime::FIELD {
                     value.serialize(DateStrEmitter(&mut *ser))?;
                 } else {
                     return Err(Error::DateInvalid)

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -6,43 +6,147 @@
 //! use toml::spanned::Spanned;
 //!
 //! #[derive(Deserialize)]
-//! struct Udoprog {
+//! struct Value {
 //!     s: Spanned<String>,
 //! }
 //!
 //! fn main() {
-//!     let t = "s = \"udoprog\"\n";
+//!     let t = "s = \"value\"\n";
 //!
-//!     let u: Udoprog = toml::from_str(t).unwrap();
+//!     let u: Value = toml::from_str(t).unwrap();
 //!
 //!     assert_eq!(u.s.start, 4);
-//!     assert_eq!(u.s.end, 13);
+//!     assert_eq!(u.s.end, 11);
 //! }
 //! ```
 
-use serde::{Serialize, Serializer};
+use serde::{de, ser};
+use std::fmt;
 
-// FIXME: use a more unique name like "toml::Spanned".
 #[doc(hidden)]
-pub const NAME: &str = "Spanned";
+pub const NAME: &'static str = "$__toml_private_Spanned";
 #[doc(hidden)]
-pub const FIELDS: &[&str] = &["value", "start", "end"];
+pub const START: &'static str = "$__toml_private_start";
+#[doc(hidden)]
+pub const END: &'static str = "$__toml_private_end";
+#[doc(hidden)]
+pub const VALUE: &'static str = "$__toml_private_value";
 
-///
-#[derive(Deserialize, Debug)]
-pub struct Spanned<T> {
-    ///
-    pub value: T,
-    ///
-    pub start: usize,
-    ///
-    pub end: usize,
+macro_rules! key_deserialize {
+    ($ident:ident, $field:expr, $name:expr) => {
+        struct $ident;
+
+        impl<'de> de::Deserialize<'de> for $ident {
+            fn deserialize<D>(deserializer: D) -> Result<$ident, D::Error>
+                where D: de::Deserializer<'de>
+            {
+                struct FieldVisitor;
+
+                impl<'de> de::Visitor<'de> for FieldVisitor {
+                    type Value = ();
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("a valid spanned field")
+                    }
+
+                    fn visit_str<E>(self, s: &str) -> Result<(), E>
+                        where E: de::Error
+                    {
+                        if s == $field {
+                            Ok(())
+                        } else {
+                            Err(de::Error::custom(
+                                concat!("expected spanned field `", $name, "`")))
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(FieldVisitor)?;
+                Ok($ident)
+            }
+        }
+    }
 }
 
-impl<T: Serialize> Serialize for Spanned<T> {
+
+/// A spanned value, indicating the range at which it is defined in the source.
+#[derive(Debug)]
+pub struct Spanned<T> {
+    /// The start range.
+    pub start: usize,
+    /// The end range (exclusive).
+    pub end: usize,
+    /// The spanned value.
+    pub value: T,
+}
+
+impl<'de, T> de::Deserialize<'de> for Spanned<T>
+    where T: de::Deserialize<'de>
+{
+    fn deserialize<D>(deserializer: D) -> Result<Spanned<T>, D::Error>
+        where D: de::Deserializer<'de>
+    {
+        struct SpannedVisitor<T>(::std::marker::PhantomData<T>);
+
+        impl<'de, T> de::Visitor<'de> for SpannedVisitor<T>
+            where T: de::Deserialize<'de>
+        {
+            type Value = Spanned<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a TOML spanned")
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Spanned<T>, V::Error>
+                where V: de::MapAccess<'de>
+            {
+                let start = visitor.next_key::<StartKey>()?;
+
+                if start.is_none() {
+                    return Err(de::Error::custom("spanned start key not found"))
+                }
+
+                let start: usize = visitor.next_value()?;
+
+                let end = visitor.next_key::<EndKey>()?;
+
+                if end.is_none() {
+                    return Err(de::Error::custom("spanned end key not found"))
+                }
+
+                let end: usize = visitor.next_value()?;
+
+                let value = visitor.next_key::<ValueKey>()?;
+
+                if value.is_none() {
+                    return Err(de::Error::custom("spanned value key not found"))
+                }
+
+                let value: T = visitor.next_value()?;
+
+                Ok(Spanned {
+                    start: start,
+                    end: end,
+                    value: value
+                })
+            }
+        }
+
+        key_deserialize!(StartKey, START, "start");
+        key_deserialize!(EndKey, END, "end");
+        key_deserialize!(ValueKey, VALUE, "value");
+
+        let visitor = SpannedVisitor(::std::marker::PhantomData);
+
+        static FIELDS: [&'static str; 3] = [START, END, VALUE];
+        deserializer.deserialize_struct(NAME, &FIELDS, visitor)
+    }
+}
+
+impl<T: ser::Serialize> ser::Serialize for Spanned<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: ser::Serializer,
     {
         self.value.serialize(serializer)
     }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,0 +1,49 @@
+//! ```
+//! #[macro_use]
+//! extern crate serde_derive;
+//!
+//! extern crate toml;
+//! use toml::spanned::Spanned;
+//!
+//! #[derive(Deserialize)]
+//! struct Udoprog {
+//!     s: Spanned<String>,
+//! }
+//!
+//! fn main() {
+//!     let t = "s = \"udoprog\"\n";
+//!
+//!     let u: Udoprog = toml::from_str(t).unwrap();
+//!
+//!     assert_eq!(u.s.start, 4);
+//!     assert_eq!(u.s.end, 13);
+//! }
+//! ```
+
+use serde::{Serialize, Serializer};
+
+// FIXME: use a more unique name like "toml::Spanned".
+#[doc(hidden)]
+pub const NAME: &str = "Spanned";
+#[doc(hidden)]
+pub const FIELDS: &[&str] = &["value", "start", "end"];
+
+///
+#[derive(Deserialize, Debug)]
+pub struct Spanned<T> {
+    ///
+    pub value: T,
+    ///
+    pub start: usize,
+    ///
+    pub end: usize,
+}
+
+impl<T: Serialize> Serialize for Spanned<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -3,7 +3,7 @@
 //! extern crate serde_derive;
 //!
 //! extern crate toml;
-//! use toml::spanned::Spanned;
+//! use toml::Spanned;
 //!
 //! #[derive(Deserialize)]
 //! struct Value {
@@ -15,8 +15,10 @@
 //!
 //!     let u: Value = toml::from_str(t).unwrap();
 //!
-//!     assert_eq!(u.s.start, 4);
-//!     assert_eq!(u.s.end, 11);
+//!     assert_eq!(u.s.start(), 4);
+//!     assert_eq!(u.s.end(), 11);
+//!     assert_eq!(u.s.get_ref(), "value");
+//!     assert_eq!(u.s.into_inner(), String::from("value"));
 //! }
 //! ```
 
@@ -36,11 +38,43 @@ pub const VALUE: &'static str = "$__toml_private_value";
 #[derive(Debug)]
 pub struct Spanned<T> {
     /// The start range.
-    pub start: usize,
+    start: usize,
     /// The end range (exclusive).
-    pub end: usize,
+    end: usize,
     /// The spanned value.
-    pub value: T,
+    value: T,
+}
+
+impl<T> Spanned<T> {
+    /// Access the start of the span of the contained value.
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Access the end of the span of the contained value.
+    pub fn end(&self) -> usize {
+        self.end
+    }
+
+    /// Get the span of the contained value.
+    pub fn span(&self) -> (usize, usize) {
+        (self.start, self.end)
+    }
+
+    /// Consumes the spanned value and returns the contained value.
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+
+    /// Returns a reference to the contained value.
+    pub fn get_ref(&self) -> &T {
+        &self.value
+    }
+
+    /// Returns a mutable reference to the contained value.
+    pub fn get_mut(&self) -> &T {
+        &self.value
+    }
 }
 
 impl<'de, T> de::Deserialize<'de> for Spanned<T>

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -118,21 +118,34 @@ impl<'a> Tokenizer<'a> {
     }
 
     pub fn eat(&mut self, expected: Token<'a>) -> Result<bool, Error> {
-        match self.peek()? {
-            Some((_, ref found)) if expected == *found => {}
-            Some(_) => return Ok(false),
-            None => return Ok(false),
-        }
+        self.eat_spanned(expected).map(|s| s.is_some())
+    }
+
+    /// Eat a value, returning it's span if it was consumed.
+    pub fn eat_spanned(&mut self, expected: Token<'a>) -> Result<Option<Span>, Error> {
+        let span = match self.peek()? {
+            Some((span, ref found)) if expected == *found => span,
+            Some(_) => return Ok(None),
+            None => return Ok(None),
+        };
+
         drop(self.next());
-        Ok(true)
+        Ok(Some(span))
     }
 
     pub fn expect(&mut self, expected: Token<'a>) -> Result<(), Error> {
+        // ignore span
+        let _ = self.expect_spanned(expected)?;
+        Ok(())
+    }
+
+    /// Expect the given token returning its span.
+    pub fn expect_spanned(&mut self, expected: Token<'a>) -> Result<Span, Error> {
         let current = self.current();
         match self.next()? {
-            Some((_, found)) => {
+            Some((span, found)) => {
                 if expected == found {
-                    Ok(())
+                    Ok(span)
                 } else {
                     Err(Error::Wanted {
                         at: current,

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,7 +12,7 @@ use serde::de;
 use serde::de::IntoDeserializer;
 
 pub use datetime::{Datetime, DatetimeParseError};
-use datetime::{DatetimeFromString, SERDE_STRUCT_FIELD_NAME};
+use datetime::{self, DatetimeFromString};
 
 /// Representation of a TOML value.
 #[derive(PartialEq, Clone, Debug)]
@@ -925,7 +925,7 @@ impl<'a, 'de> de::Visitor<'de> for DatetimeOrTable<'a> {
     fn visit_str<E>(self, s: &str) -> Result<bool, E>
         where E: de::Error,
     {
-        if s == SERDE_STRUCT_FIELD_NAME {
+        if s == datetime::FIELD {
             Ok(true)
         } else {
             self.key.push_str(s);
@@ -936,7 +936,7 @@ impl<'a, 'de> de::Visitor<'de> for DatetimeOrTable<'a> {
     fn visit_string<E>(self, s: String) -> Result<bool, E>
         where E: de::Error,
     {
-        if s == SERDE_STRUCT_FIELD_NAME {
+        if s == datetime::FIELD {
             Ok(true)
         } else {
             *self.key = s;

--- a/test-suite/tests/spanned.rs
+++ b/test-suite/tests/spanned.rs
@@ -23,8 +23,21 @@ fn test_spanned_field() {
 
     good::<String>("foo = \"foo\"", "\"foo\"");
     good::<u32>("foo = 42", "42");
+    // leading plus
+    good::<u32>("foo = +42", "+42");
+    // table
     good::<HashMap<String, u32>>(
         "foo = {\"foo\" = 42, \"bar\" = 42}",
         "{\"foo\" = 42, \"bar\" = 42}"
+    );
+    // array
+    good::<Vec<u32>>(
+        "foo = [0, 1, 2, 3, 4]",
+        "[0, 1, 2, 3, 4]"
+    );
+    // datetime
+    good::<String>(
+        "foo = \"1997-09-09T09:09:09Z\"",
+        "\"1997-09-09T09:09:09Z\""
     );
 }

--- a/test-suite/tests/spanned.rs
+++ b/test-suite/tests/spanned.rs
@@ -34,9 +34,9 @@ fn test_spanned_field() {
     fn good<'de, T>(s: &'de str, expected: &str) where T: serde::Deserialize<'de> {
         let foo: Foo<T> = toml::from_str(s).unwrap();
 
-        assert_eq!(6, foo.foo.start);
-        assert_eq!(s.len(), foo.foo.end);
-        assert_eq!(expected, &s[foo.foo.start..foo.foo.end]);
+        assert_eq!(6, foo.foo.start());
+        assert_eq!(s.len(), foo.foo.end());
+        assert_eq!(expected, &s[foo.foo.start()..foo.foo.end()]);
     }
 
     good::<String>("foo = \"foo\"", "\"foo\"");

--- a/test-suite/tests/spanned.rs
+++ b/test-suite/tests/spanned.rs
@@ -4,7 +4,25 @@ extern crate toml;
 extern crate serde_derive;
 
 use toml::Spanned;
+use toml::value::Datetime;
 use std::collections::HashMap;
+
+/// A set of good datetimes.
+pub fn good_datetimes() -> Vec<&'static str> {
+    let mut v = Vec::new();
+    v.push("1997-09-09T09:09:09Z");
+    v.push("1997-09-09T09:09:09+09:09");
+    v.push("1997-09-09T09:09:09-09:09");
+    v.push("1997-09-09T09:09:09");
+    v.push("1997-09-09");
+    v.push("09:09:09");
+    v.push("1997-09-09T09:09:09.09Z");
+    v.push("1997-09-09T09:09:09.09+09:09");
+    v.push("1997-09-09T09:09:09.09-09:09");
+    v.push("1997-09-09T09:09:09.09");
+    v.push("09:09:09.09");
+    v
+}
 
 #[test]
 fn test_spanned_field() {
@@ -40,4 +58,9 @@ fn test_spanned_field() {
         "foo = \"1997-09-09T09:09:09Z\"",
         "\"1997-09-09T09:09:09Z\""
     );
+
+    for expected in good_datetimes() {
+        let s = format!("foo = {}", expected);
+        good::<Datetime>(&s, expected);
+    }
 }

--- a/test-suite/tests/spanned.rs
+++ b/test-suite/tests/spanned.rs
@@ -1,0 +1,30 @@
+extern crate serde;
+extern crate toml;
+#[macro_use]
+extern crate serde_derive;
+
+use toml::Spanned;
+use std::collections::HashMap;
+
+#[test]
+fn test_spanned_field() {
+    #[derive(Deserialize)]
+    struct Foo<T> {
+        foo: Spanned<T>,
+    }
+
+    fn good<'de, T>(s: &'de str, expected: &str) where T: serde::Deserialize<'de> {
+        let foo: Foo<T> = toml::from_str(s).unwrap();
+
+        assert_eq!(6, foo.foo.start);
+        assert_eq!(s.len(), foo.foo.end);
+        assert_eq!(expected, &s[foo.foo.start..foo.foo.end]);
+    }
+
+    good::<String>("foo = \"foo\"", "\"foo\"");
+    good::<u32>("foo = 42", "42");
+    good::<HashMap<String, u32>>(
+        "foo = {\"foo\" = 42, \"bar\" = 42}",
+        "{\"foo\" = 42, \"bar\" = 42}"
+    );
+}


### PR DESCRIPTION
This PR introduces Spanned based on the previous POC by @dtolnay.

Internally we deserialize spans as "intermediate structs" with special naming conventions, which communicates to the `Deserializer` that it should emit a Map with similarly special names that we can pick up.

This PR contains a couple of changes:

* Introduces a `Spanned<T>` type that can be used in structs to encapsulate spans.
* Unified the naming convention of constants for `datetime` and `spanned`.
* Added `eat_spanned` and `expect_spanned` to `Tokenizer` to correctly parse tables and arrays. 

I'm unsure it is complete, the infrastructure needed to support Datetime permeates more of the deserialize infrastructure, but I haven't been able to decipher _why_ yet. Any feedback is appreciated.

#### Future work

Ironically this doesn't help me with my original problem, but it's a fair step down the road. I use `toml::Value` in a similar way that `Cargo` uses it to permit more flexible decoding than is afforded through databinding. Introducing spans into the existing `toml::Value` would not be a backwards compatible change, so the only alternative I see is to have separate types (e.g. `toml::SpannedValue`) which contains the necessary spans. Suggestions are welcome.