### PR TITLE
Add from_reader and to_writer convenience methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ pub mod ser;
 pub use ser::{to_string, to_string_pretty, to_vec, Serializer};
 pub mod de;
 #[doc(no_inline)]
-pub use de::{from_slice, from_str, Deserializer};
+pub use de::{from_reader, from_slice, from_str, Deserializer};
 mod tokens;
 
 #[doc(hidden)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ mod datetime;
 
 pub mod ser;
 #[doc(no_inline)]
-pub use ser::{to_string, to_string_pretty, to_vec, Serializer};
+pub use ser::{to_string, to_string_pretty, to_vec, to_writer, Serializer};
 pub mod de;
 #[doc(no_inline)]
 pub use de::{from_reader, from_slice, from_str, Deserializer};


### PR DESCRIPTION
Resolves #215, resolves #216.

I used `Arc<io::Error>` as suggested in #215.