### PR TITLE
Avoid panic on pretty string ending in single quote

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -585,6 +585,10 @@ impl<'a> Serializer<'a> {
                     }
                 }
             }
+            if can_be_pretty && found_singles > 0 && value.ends_with('\'') {
+                // We cannot escape the ending quote so we must use """
+                can_be_pretty = false;
+            }
             if !can_be_pretty {
                 debug_assert!(ty != Type::OnelineTripple);
                 return Repr::Std(ty);

--- a/test-suite/tests/valid.rs
+++ b/test-suite/tests/valid.rs
@@ -250,3 +250,7 @@ test!(table_array_nest_no_keys,
 test!(dotted_keys,
       include_str!("valid/dotted-keys.toml"),
       include_str!("valid/dotted-keys.json"));
+
+test!(quote_surrounded_value,
+      include_str!("valid/quote-surrounded-value.toml"),
+      include_str!("valid/quote-surrounded-value.json"));

--- a/test-suite/tests/valid/quote-surrounded-value.json
+++ b/test-suite/tests/valid/quote-surrounded-value.json
@@ -1,0 +1,10 @@
+{
+  "double": {
+    "type": "string",
+    "value": "\"double quotes here\""
+  },
+  "single": {
+    "type": "string",
+    "value": "'single quotes here'"
+  }
+}

--- a/test-suite/tests/valid/quote-surrounded-value.toml
+++ b/test-suite/tests/valid/quote-surrounded-value.toml
@@ -1,0 +1,2 @@
+double = '"double quotes here"'
+single = "'single quotes here'"


### PR DESCRIPTION
Fixes #262.

The `can_be_pretty && found_singles > 0` check is not required for correctness and may be an unwarranted attempt at optimization, let me know if you'd rather get rid of it.

As a side note I also found the `can_be_pretty` variable name here confusing. It seems like e.g. `can_be_literal` would be more accurate. After all, it only controls whether `Repr::Std` or `Repr::Literal` is used.