### PR TITLE
Issue 255: Externally tagged enum deserialization

### DIFF
--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -11,7 +11,8 @@ extern crate serde_derive;
 #[derive(Debug, Deserialize)]
 struct Config {
     plain: MyEnum,
-    // tuple: MyEnum,
+    plain_table: MyEnum,
+    tuple: MyEnum,
     #[serde(rename = "struct")]
     structv: MyEnum,
     newtype: MyEnum,
@@ -29,12 +30,13 @@ enum MyEnum {
 fn main() {
     let toml_str = r#"
     plain = "Plain"
-    # tuple = { 0 = 123, 1 = true }
+    plain_table = { Plain = {} }
+    tuple = { Tuple = { 0 = 123, 1 = true } }
     struct = { Struct = { value = 123 } }
     newtype = { NewType = "value" }
     my_enum = [
         { Plain = {} },
-        # { Tuple = { 0 = 123, 1 = true } },
+        { Tuple = { 0 = 123, 1 = true } },
         { NewType = "value" },
         { Struct = { value = 123 } }
     ]"#;

--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -1,0 +1,40 @@
+//! An example showing off the usage of `Deserialize` to automatically decode
+//! TOML into a Rust `struct`, with enums.
+
+#![deny(warnings)]
+
+extern crate toml;
+#[macro_use]
+extern crate serde_derive;
+
+/// This is what we're going to decode into.
+#[derive(Debug, Deserialize)]
+struct Config {
+    plain: MyEnum,
+    // tuple: MyEnum,
+    #[serde(rename = "struct")]
+    structv: MyEnum,
+    my_enum: Vec<MyEnum>,
+}
+
+#[derive(Debug, Deserialize)]
+enum MyEnum {
+    Plain,
+    Tuple(i64, bool),
+    Struct { value: i64 },
+}
+
+fn main() {
+    let toml_str = r#"
+    plain = "Plain"
+    # tuple = { 0 = 123, 1 = true }
+    struct = { Struct = { value = 123 } }
+    my_enum = [
+        { Plain = {} },
+        # { Tuple = { 0 = 123, 1 = true } },
+        { Struct = { value = 123 } }
+    ]"#;
+
+    let decoded: Config = toml::from_str(toml_str).unwrap();
+    println!("{:#?}", decoded);
+}

--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -14,6 +14,7 @@ struct Config {
     // tuple: MyEnum,
     #[serde(rename = "struct")]
     structv: MyEnum,
+    newtype: MyEnum,
     my_enum: Vec<MyEnum>,
 }
 
@@ -21,6 +22,7 @@ struct Config {
 enum MyEnum {
     Plain,
     Tuple(i64, bool),
+    NewType(String),
     Struct { value: i64 },
 }
 
@@ -29,9 +31,11 @@ fn main() {
     plain = "Plain"
     # tuple = { 0 = 123, 1 = true }
     struct = { Struct = { value = 123 } }
+    newtype = { NewType = "value" }
     my_enum = [
         { Plain = {} },
         # { Tuple = { 0 = 123, 1 = true } },
+        { NewType = "value" },
         { Struct = { value = 123 } }
     ]"#;
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -829,7 +829,7 @@ impl<'de> de::VariantAccess<'de> for TableEnumDeserializer<'de> {
                     })
                     // Fold all values into a `Vec`, or return the first error.
                     .fold(Ok(Vec::with_capacity(len)), |result, value_result| {
-                        result.and_then(|mut tuple_values| match value_result {
+                        result.and_then(move |mut tuple_values| match value_result {
                             Ok(value) => {
                                 tuple_values.push(value);
                                 Ok(tuple_values)

--- a/src/de.rs
+++ b/src/de.rs
@@ -162,8 +162,18 @@ enum ErrorKind {
     /// A struct was expected but something else was found
     ExpectedString,
 
-    /// A tuple with a certain number of elements was expected but something else was found
+    /// A tuple with a certain number of elements was expected but something
+    /// else was found.
     ExpectedTuple(usize),
+
+    /// Expected table keys to be in increasing tuple index order, but something
+    /// else was found.
+    ExpectedTupleIndex {
+        /// Expected index.
+        expected: usize,
+        /// Key that was specified.
+        found: String,
+    },
 
     /// An empty table was expected but entries were found
     ExpectedEmptyTable,
@@ -812,16 +822,24 @@ impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
                 let tuple_values = values
                     .into_iter()
                     .enumerate()
-                    .filter_map(|(index, (key, value))| {
-                        // TODO: Is this expensive?
-                        if key == format!("{}", index) {
-                            Some(value)
-                        } else {
-                            // TODO: Err()
-                            unimplemented!()
-                        }
+                    .map(|(index, (key, value))| match key.parse::<usize>() {
+                        Ok(key_index) if key_index == index => Ok(value),
+                        Ok(_) | Err(_) => Err(Error::from_kind(ErrorKind::ExpectedTupleIndex {
+                            expected: index,
+                            found: key.to_string(),
+                        })),
                     })
-                    .collect::<Vec<_>>(); // TODO: is this expensive?
+                    // Fold all values into a `Vec`, or return the first error.
+                    .fold(Ok(Vec::with_capacity(len)), |result, value_result| {
+                        result.and_then(|mut tuple_values| match value_result {
+                            Ok(value) => {
+                                tuple_values.push(value);
+                                Ok(tuple_values)
+                            }
+                            // `Result<de::Value, Self::Error>` to `Result<Vec<_>, Self::Error>`
+                            Err(e) => Err(e),
+                        })
+                    })?;
 
                 if tuple_values.len() == len {
                     de::Deserializer::deserialize_seq(
@@ -1521,7 +1539,11 @@ impl fmt::Display for Error {
             ErrorKind::MultilineStringKey => "multiline strings are not allowed for key".fmt(f)?,
             ErrorKind::Custom => self.inner.message.fmt(f)?,
             ErrorKind::ExpectedString => "expected string".fmt(f)?,
-            ErrorKind::ExpectedTuple(l) => write!(f, "expected tuple with length {}", l)?,
+            ErrorKind::ExpectedTuple(l) => write!(f, "expected table with length {}", l)?,
+            ErrorKind::ExpectedTupleIndex {
+                expected,
+                ref found,
+            } => write!(f, "expected table key `{}`, but was `{}`", expected, found)?,
             ErrorKind::ExpectedEmptyTable => "expected empty table".fmt(f)?,
             ErrorKind::DottedKeyInvalidType => {
                 "dotted key attempted to extend non-table type".fmt(f)?
@@ -1570,7 +1592,8 @@ impl error::Error for Error {
             ErrorKind::MultilineStringKey => "invalid multiline string for key",
             ErrorKind::Custom => "a custom error",
             ErrorKind::ExpectedString => "expected string",
-            ErrorKind::ExpectedTuple(_) => "expected tuple",
+            ErrorKind::ExpectedTuple(_) => "expected table length",
+            ErrorKind::ExpectedTupleIndex { .. } => "expected table key",
             ErrorKind::ExpectedEmptyTable => "expected empty table",
             ErrorKind::DottedKeyInvalidType => "dotted key invalid type",
             ErrorKind::__Nonexhaustive => panic!(),

--- a/src/de.rs
+++ b/src/de.rs
@@ -558,9 +558,9 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
         }
 
         match &self.value.e {
-            E::InlineTable(values) | E::DottedTable(values) => {
+            &E::InlineTable(ref values) | &E::DottedTable(ref values) => {
                 let extra_fields = values.iter()
-                    .filter_map(|(key, _val)| {
+                    .filter_map(|(ref key, ref _val)| {
                         if !fields.contains(&&(**key)) {
                             Some(key.clone())
                         } else {

--- a/src/de.rs
+++ b/src/de.rs
@@ -568,7 +568,8 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
             match &self.value.e {
                 &E::InlineTable(ref values) | &E::DottedTable(ref values) => {
                     let extra_fields = values.iter()
-                        .filter_map(|(ref key, ref _val)| {
+                        .filter_map(|key_value| {
+                            let (ref key, ref _val) = *key_value;
                             if !fields.contains(&&(**key)) {
                                 Some(key.clone())
                             } else {

--- a/src/de.rs
+++ b/src/de.rs
@@ -585,7 +585,27 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
     {
         match self.value.e {
             E::String(val) => visitor.visit_enum(val.into_deserializer()),
-            _ => Err(Error::from_kind(ErrorKind::ExpectedString))
+            E::InlineTable(values) | E::DottedTable(values) => {
+                if values.len() != 1 {
+                    Err(Error::from_kind(ErrorKind::Wanted {
+                        expected: "exactly 1 element",
+                        found: if values.is_empty() {
+                            "zero elements"
+                        } else {
+                            "more than 1 element"
+                        },
+                    }))
+                } else {
+                    visitor.visit_enum(InlineTableDeserializer {
+                        values: values.into_iter(),
+                        next_value: None,
+                    })
+                }
+            }
+            e @ _ => Err(Error::from_kind(ErrorKind::Wanted {
+                expected: "string or table",
+                found: e.type_name(),
+            })),
         }
     }
 
@@ -724,6 +744,70 @@ impl<'de> de::MapAccess<'de> for InlineTableDeserializer<'de> {
     }
 }
 
+impl<'de> de::EnumAccess<'de> for InlineTableDeserializer<'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let (key, value) = match self.values.next() {
+            Some(pair) => pair,
+            None => {
+                return Err(Error::from_kind(ErrorKind::Wanted {
+                    expected: "table with exactly 1 entry",
+                    found: "empty map",
+                }))
+            }
+        };
+        self.next_value = Some(value);
+
+        seed.deserialize(StrDeserializer::new(key))
+            .map(|val| (val, self))
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
+    type Error = Error;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        // TODO: Error handling if there are entries
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(ValueDeserializer::new(
+            self.next_value.expect("Expected value"),
+        ))
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        unimplemented!()
+    }
+
+    fn struct_variant<V>(
+        self,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        de::Deserializer::deserialize_struct(
+            ValueDeserializer::new(self.next_value.expect("Expected value")),
+            "", // TODO: this should be the variant name
+            fields,
+            visitor,
+        )
+    }
+}
 
 impl<'a> Deserializer<'a> {
     /// Creates a new deserializer which will be deserializing the string
@@ -1508,6 +1592,21 @@ enum E<'a> {
     Array(Vec<Value<'a>>),
     InlineTable(Vec<(Cow<'a, str>, Value<'a>)>),
     DottedTable(Vec<(Cow<'a, str>, Value<'a>)>),
+}
+
+impl<'a> E<'a> {
+    fn type_name(&self) -> &'static str {
+        match *self {
+            E::String(..) => "string",
+            E::Integer(..) => "integer",
+            E::Float(..) => "float",
+            E::Boolean(..) => "boolean",
+            E::Datetime(..) => "datetime",
+            E::Array(..) => "array",
+            E::InlineTable(..) => "inline table",
+            E::DottedTable(..) => "dotted table",
+        }
+    }
 }
 
 impl<'a> Value<'a> {

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -1,0 +1,153 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
+
+#[derive(Debug, Deserialize, PartialEq)]
+enum TheEnum {
+    Plain,
+    Tuple(i64, bool),
+    NewType(String),
+    Struct { value: i64 },
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Val {
+    val: TheEnum,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Multi {
+    enums: Vec<TheEnum>,
+}
+
+mod enum_unit {
+    use super::*;
+
+    #[test]
+    fn from_str() {
+        assert_eq!(TheEnum::Plain, toml::from_str("\"Plain\"").unwrap());
+    }
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(TheEnum::Plain, toml::from_str("{ Plain = {} }").unwrap());
+        assert_eq!(
+            Val {
+                val: TheEnum::Plain
+            },
+            toml::from_str("val = { Plain = {} }").unwrap()
+        );
+    }
+
+    #[test]
+    fn from_dotted_table() {
+        assert_eq!(TheEnum::Plain, toml::from_str("[Plain]\n").unwrap());
+    }
+}
+
+mod enum_tuple {
+    use super::*;
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(
+            TheEnum::Tuple(-123, true),
+            toml::from_str("{ Tuple = { 0 = -123, 1 = true } }").unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::Tuple(-123, true)
+            },
+            toml::from_str("val = { Tuple = { 0 = -123, 1 = true } }").unwrap()
+        );
+    }
+
+    #[test]
+    fn from_dotted_table() {
+        assert_eq!(
+            TheEnum::Tuple(-123, true),
+            toml::from_str(
+                r#"[Tuple]
+                0 = -123
+                1 = true
+                "#
+            )
+            .unwrap()
+        );
+    }
+}
+
+mod enum_newtype {
+    use super::*;
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(
+            TheEnum::NewType("value".to_string()),
+            toml::from_str(r#"{ NewType = "value" }"#).unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::NewType("value".to_string()),
+            },
+            toml::from_str(r#"val = { NewType = "value" }"#).unwrap()
+        );
+    }
+}
+
+mod enum_struct {
+    use super::*;
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(
+            TheEnum::Struct { value: -123 },
+            toml::from_str("{ Struct = { value = -123 } }").unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::Struct { value: -123 }
+            },
+            toml::from_str("val = { Struct = { value = -123 } }").unwrap()
+        );
+    }
+
+    #[test]
+    fn from_dotted_table() {
+        assert_eq!(
+            TheEnum::Struct { value: -123 },
+            toml::from_str(
+                r#"[Struct]
+                value = -123
+                "#
+            )
+            .unwrap()
+        );
+    }
+}
+
+mod enum_array {
+    use super::*;
+
+    #[test]
+    fn from_inline_tables() {
+        let toml_str = r#"
+            enums = [
+                { Plain = {} },
+                { Tuple = { 0 = -123, 1 = true } },
+                { NewType = "value" },
+                { Struct = { value = -123 } }
+            ]"#;
+        assert_eq!(
+            Multi {
+                enums: vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_string()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+            toml::from_str(toml_str).unwrap()
+        );
+    }
+}

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -20,6 +20,46 @@ struct Multi {
     enums: Vec<TheEnum>,
 }
 
+#[test]
+fn invalid_variant_returns_error_with_good_message_string() {
+    let error = toml::from_str::<TheEnum>("\"NonExistent\"")
+        .expect_err("Expected deserialization to fail.");
+
+    assert_eq!(
+        error.to_string(),
+        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"
+    );
+}
+
+#[test]
+fn invalid_variant_returns_error_with_good_message_inline_table() {
+    let error = toml::from_str::<TheEnum>("{ NonExistent = {} }")
+        .expect_err("Expected deserialization to fail.");
+    assert_eq!(
+        error.to_string(),
+        "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"
+    );
+}
+
+#[test]
+fn extra_field_returns_expected_empty_table_error() {
+    let error = toml::from_str::<TheEnum>("{ Plain = { extra_field = 404 } }")
+        .expect_err("Expected deserialization to fail.");
+
+    assert_eq!(error.to_string(), "expected empty table");
+}
+
+#[test]
+fn extra_field_returns_expected_empty_table_error_struct_variant() {
+    let error = toml::from_str::<TheEnum>("{ Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }")
+        .expect_err("Expected deserialization to fail.");
+
+    assert_eq!(
+        error.to_string(),
+        r#"unexpected keys in table: `["extra_0", "extra_1"]`, available keys: `["value"]`"#
+    );
+}
+
 mod enum_unit {
     use super::*;
 

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -93,6 +93,26 @@ mod enum_newtype {
             toml::from_str(r#"val = { NewType = "value" }"#).unwrap()
         );
     }
+
+    #[test]
+    #[ignore = "Unimplemented: https://github.com/alexcrichton/toml-rs/pull/264#issuecomment-431707209"]
+    fn from_dotted_table() {
+        assert_eq!(
+            TheEnum::NewType("value".to_string()),
+            toml::from_str(r#"NewType = "value""#).unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::NewType("value".to_string()),
+            },
+            toml::from_str(
+                r#"[val]
+                NewType = "value"
+                "#
+            )
+            .unwrap()
+        );
+    }
 }
 
 mod enum_struct {
@@ -138,6 +158,34 @@ mod enum_array {
                 { NewType = "value" },
                 { Struct = { value = -123 } }
             ]"#;
+        assert_eq!(
+            Multi {
+                enums: vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_string()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+            toml::from_str(toml_str).unwrap()
+        );
+    }
+
+    #[test]
+    #[ignore = "Unimplemented: https://github.com/alexcrichton/toml-rs/pull/264#issuecomment-431707209"]
+    fn from_dotted_table() {
+        let toml_str = r#"[[enums]]
+            Plain = {}
+
+            [[enums]]
+            Tuple = { 0 = -123, 1 = true }
+
+            [[enums]]
+            NewType = "value"
+
+            [[enums]]
+            Struct = { value = -123 }
+            "#;
         assert_eq!(
             Multi {
                 enums: vec![

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -22,8 +22,7 @@ struct Multi {
 
 #[test]
 fn invalid_variant_returns_error_with_good_message_string() {
-    let error = toml::from_str::<TheEnum>("\"NonExistent\"")
-        .expect_err("Expected deserialization to fail.");
+    let error = toml::from_str::<TheEnum>("\"NonExistent\"").unwrap_err();
 
     assert_eq!(
         error.to_string(),
@@ -33,8 +32,7 @@ fn invalid_variant_returns_error_with_good_message_string() {
 
 #[test]
 fn invalid_variant_returns_error_with_good_message_inline_table() {
-    let error = toml::from_str::<TheEnum>("{ NonExistent = {} }")
-        .expect_err("Expected deserialization to fail.");
+    let error = toml::from_str::<TheEnum>("{ NonExistent = {} }").unwrap_err();
     assert_eq!(
         error.to_string(),
         "unknown variant `NonExistent`, expected one of `Plain`, `Tuple`, `NewType`, `Struct`"
@@ -43,8 +41,7 @@ fn invalid_variant_returns_error_with_good_message_inline_table() {
 
 #[test]
 fn extra_field_returns_expected_empty_table_error() {
-    let error = toml::from_str::<TheEnum>("{ Plain = { extra_field = 404 } }")
-        .expect_err("Expected deserialization to fail.");
+    let error = toml::from_str::<TheEnum>("{ Plain = { extra_field = 404 } }").unwrap_err();
 
     assert_eq!(error.to_string(), "expected empty table");
 }
@@ -52,7 +49,7 @@ fn extra_field_returns_expected_empty_table_error() {
 #[test]
 fn extra_field_returns_expected_empty_table_error_struct_variant() {
     let error = toml::from_str::<TheEnum>("{ Struct = { value = 123, extra_0 = 0, extra_1 = 1 } }")
-        .expect_err("Expected deserialization to fail.");
+        .unwrap_err();
 
     assert_eq!(
         error.to_string(),


### PR DESCRIPTION
cc: #225, #222

~~The tuple variant hasn't been implemented yet, I'm having trouble figuring it out.~~
See #225 for ongoing discussion -- what should / should not be supported.

Short, the following TOML:

```toml
plain = "Plain"
plain_table = { Plain = {} }
tuple = { Tuple = { 0 = 123, 1 = true } }
struct = { Struct = { value = 123 } }
newtype = { NewType = "value" }
my_enum = [
    { Plain = {} },
    { Tuple = { 0 = 123, 1 = true } },
    { NewType = "value" },
    { Struct = { value = 123 } }
]
```

with the following types:

```rust
#[derive(Debug, Deserialize)]
struct Config {
    plain: MyEnum,
    plain_table: MyEnum,
    tuple: MyEnum,
    #[serde(rename = "struct")]
    structv: MyEnum,
    newtype: MyEnum,
    my_enum: Vec<MyEnum>,
}

#[derive(Debug, Deserialize)]
enum MyEnum {
    Plain,
    Tuple(i64, bool),
    NewType(String),
    Struct { value: i64 },
}
```

deserializes to:

```rust
Config {
    plain: Plain,
    plain_table: Plain,
    tuple: Tuple(
        123,
        true
    ),
    structv: Struct {
        value: 123
    },
    newtype: NewType(
        "value"
    ),
    my_enum: [
        Plain,
        Tuple(
            123,
            true
        ),
        NewType(
            "value"
        ),
        Struct {
            value: 123
        }
    ]
}
```