### PR TITLE
[Need Help] External Enum Serialization

### DIFF
--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -11,7 +11,8 @@ extern crate serde_derive;
 #[derive(Debug, Deserialize)]
 struct Config {
     plain: MyEnum,
-    // tuple: MyEnum,
+    plain_table: MyEnum,
+    tuple: MyEnum,
     #[serde(rename = "struct")]
     structv: MyEnum,
     newtype: MyEnum,
@@ -29,12 +30,13 @@ enum MyEnum {
 fn main() {
     let toml_str = r#"
     plain = "Plain"
-    # tuple = { 0 = 123, 1 = true }
+    plain_table = { Plain = {} }
+    tuple = { Tuple = { 0 = 123, 1 = true } }
     struct = { Struct = { value = 123 } }
     newtype = { NewType = "value" }
     my_enum = [
         { Plain = {} },
-        # { Tuple = { 0 = 123, 1 = true } },
+        { Tuple = { 0 = 123, 1 = true } },
         { NewType = "value" },
         { Struct = { value = 123 } }
     ]"#;

--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -1,0 +1,40 @@
+//! An example showing off the usage of `Deserialize` to automatically decode
+//! TOML into a Rust `struct`, with enums.
+
+#![deny(warnings)]
+
+extern crate toml;
+#[macro_use]
+extern crate serde_derive;
+
+/// This is what we're going to decode into.
+#[derive(Debug, Deserialize)]
+struct Config {
+    plain: MyEnum,
+    // tuple: MyEnum,
+    #[serde(rename = "struct")]
+    structv: MyEnum,
+    my_enum: Vec<MyEnum>,
+}
+
+#[derive(Debug, Deserialize)]
+enum MyEnum {
+    Plain,
+    Tuple(i64, bool),
+    Struct { value: i64 },
+}
+
+fn main() {
+    let toml_str = r#"
+    plain = "Plain"
+    # tuple = { 0 = 123, 1 = true }
+    struct = { Struct = { value = 123 } }
+    my_enum = [
+        { Plain = {} },
+        # { Tuple = { 0 = 123, 1 = true } },
+        { Struct = { value = 123 } }
+    ]"#;
+
+    let decoded: Config = toml::from_str(toml_str).unwrap();
+    println!("{:#?}", decoded);
+}

--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -14,6 +14,7 @@ struct Config {
     // tuple: MyEnum,
     #[serde(rename = "struct")]
     structv: MyEnum,
+    newtype: MyEnum,
     my_enum: Vec<MyEnum>,
 }
 
@@ -21,6 +22,7 @@ struct Config {
 enum MyEnum {
     Plain,
     Tuple(i64, bool),
+    NewType(String),
     Struct { value: i64 },
 }
 
@@ -29,9 +31,11 @@ fn main() {
     plain = "Plain"
     # tuple = { 0 = 123, 1 = true }
     struct = { Struct = { value = 123 } }
+    newtype = { NewType = "value" }
     my_enum = [
         { Plain = {} },
         # { Tuple = { 0 = 123, 1 = true } },
+        { NewType = "value" },
         { Struct = { value = 123 } }
     ]"#;
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -161,9 +161,6 @@ enum ErrorKind {
     /// type.
     Custom,
 
-    /// A struct was expected but something else was found
-    ExpectedString,
-
     /// A tuple with a certain number of elements was expected but something
     /// else was found.
     ExpectedTuple(usize),
@@ -201,49 +198,7 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
     where
         V: de::Visitor<'de>,
     {
-        let mut tables = Vec::new();
-        let mut cur_table = Table {
-            at: 0,
-            header: Vec::new(),
-            values: None,
-            array: false,
-        };
-
-        while let Some(line) = self.line()? {
-            match line {
-                Line::Table {
-                    at,
-                    mut header,
-                    array,
-                } => {
-                    if !cur_table.header.is_empty() || cur_table.values.is_some() {
-                        tables.push(cur_table);
-                    }
-                    cur_table = Table {
-                        at: at,
-                        header: Vec::new(),
-                        values: Some(Vec::new()),
-                        array: array,
-                    };
-                    loop {
-                        let part = header.next().map_err(|e| self.token_error(e));
-                        match part? {
-                            Some(part) => cur_table.header.push(part),
-                            None => break,
-                        }
-                    }
-                }
-                Line::KeyValue(key, value) => {
-                    if cur_table.values.is_none() {
-                        cur_table.values = Some(Vec::new());
-                    }
-                    self.add_dotted_key(key, value, cur_table.values.as_mut().unwrap())?;
-                }
-            }
-        }
-        if !cur_table.header.is_empty() || cur_table.values.is_some() {
-            tables.push(cur_table);
-        }
+        let mut tables = self.tables()?;
 
         visitor.visit_map(MapVisitor {
             values: Vec::new().into_iter(),
@@ -258,6 +213,7 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
         })
     }
 
+    // Called when the type to deserialize is an enum, as opposed to a field in the type.
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
@@ -267,13 +223,34 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
     where
         V: de::Visitor<'de>,
     {
-        if let Some(next) = self.next()? {
-            match next {
-                (_, Token::String { val, .. }) => visitor.visit_enum(val.into_deserializer()),
-                _ => Err(Error::from_kind(ErrorKind::ExpectedString)),
+        let (value, name) = self.string_or_table()?;
+        match value.e {
+            E::String(val) => visitor.visit_enum(val.into_deserializer()),
+            E::InlineTable(values) => {
+                if values.len() != 1 {
+                    Err(Error::from_kind(ErrorKind::Wanted {
+                        expected: "exactly 1 element",
+                        found: if values.is_empty() {
+                            "zero elements"
+                        } else {
+                            "more than 1 element"
+                        },
+                    }))
+                } else {
+                    visitor.visit_enum(InlineTableDeserializer {
+                        values: values.into_iter(),
+                        next_value: None,
+                    })
+                }
             }
-        } else {
-            Err(Error::from_kind(ErrorKind::UnexpectedEof))
+            E::DottedTable(_) => visitor.visit_enum(DottedTableDeserializer {
+                name: name.expect("Expected table header to be passed."),
+                value: value,
+            }),
+            e @ _ => Err(Error::from_kind(ErrorKind::Wanted {
+                expected: "string or table",
+                found: e.type_name(),
+            })),
         }
     }
 
@@ -626,7 +603,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
     {
         match self.value.e {
             E::String(val) => visitor.visit_enum(val.into_deserializer()),
-            E::InlineTable(values) | E::DottedTable(values) => {
+            E::InlineTable(values) => {
                 if values.len() != 1 {
                     Err(Error::from_kind(ErrorKind::Wanted {
                         expected: "exactly 1 element",
@@ -644,7 +621,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
                 }
             }
             e @ _ => Err(Error::from_kind(ErrorKind::Wanted {
-                expected: "string or table",
+                expected: "string or inline table",
                 found: e.type_name(),
             })),
         }
@@ -765,6 +742,25 @@ impl<'de> de::Deserializer<'de> for DatetimeFieldDeserializer {
     }
 }
 
+struct DottedTableDeserializer<'a> {
+    name: Cow<'a, str>,
+    value: Value<'a>,
+}
+
+impl<'de> de::EnumAccess<'de> for DottedTableDeserializer<'de> {
+    type Error = Error;
+    type Variant = TableEnumDeserializer<'de>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: de::DeserializeSeed<'de>,
+    {
+        let (name, value) = (self.name, self.value);
+        seed.deserialize(StrDeserializer::new(name))
+            .map(|val| (val, TableEnumDeserializer { value: value }))
+    }
+}
+
 struct InlineTableDeserializer<'a> {
     values: vec::IntoIter<(Cow<'a, str>, Value<'a>)>,
     next_value: Option<Value<'a>>,
@@ -796,7 +792,7 @@ impl<'de> de::MapAccess<'de> for InlineTableDeserializer<'de> {
 
 impl<'de> de::EnumAccess<'de> for InlineTableDeserializer<'de> {
     type Error = Error;
-    type Variant = Self;
+    type Variant = TableEnumDeserializer<'de>;
 
     fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
     where
@@ -811,18 +807,22 @@ impl<'de> de::EnumAccess<'de> for InlineTableDeserializer<'de> {
                 }))
             }
         };
-        self.next_value = Some(value);
 
         seed.deserialize(StrDeserializer::new(key))
-            .map(|val| (val, self))
+            .map(|val| (val, TableEnumDeserializer { value: value }))
     }
 }
 
-impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
+/// Deserializes table values into enum variants.
+struct TableEnumDeserializer<'a> {
+    value: Value<'a>,
+}
+
+impl<'de> de::VariantAccess<'de> for TableEnumDeserializer<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Self::Error> {
-        match self.next_value.expect("Expected value").e {
+        match self.value.e {
             E::InlineTable(values) | E::DottedTable(values) => {
                 if values.len() == 0 {
                     Ok(())
@@ -841,17 +841,14 @@ impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        seed.deserialize(ValueDeserializer::new(
-            self.next_value.expect("Expected value"),
-        ))
+        seed.deserialize(ValueDeserializer::new(self.value))
     }
 
     fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        let next_value = self.next_value.expect("Expected value");
-        match next_value.e {
+        match self.value.e {
             E::InlineTable(values) | E::DottedTable(values) => {
                 let tuple_values = values
                     .into_iter()
@@ -879,8 +876,8 @@ impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
                     de::Deserializer::deserialize_seq(
                         ValueDeserializer::new(Value {
                             e: E::Array(tuple_values),
-                            start: next_value.start,
-                            end: next_value.end,
+                            start: self.value.start,
+                            end: self.value.end,
                         }),
                         visitor,
                     )
@@ -904,7 +901,7 @@ impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
         V: de::Visitor<'de>,
     {
         de::Deserializer::deserialize_struct(
-            ValueDeserializer::new(self.next_value.expect("Expected value")),
+            ValueDeserializer::new(self.value),
             "", // TODO: this should be the variant name
             fields,
             visitor,
@@ -939,6 +936,53 @@ impl<'a> Deserializer<'a> {
     /// this behavior for backwards compatibility with older toml-rs versions.
     pub fn set_require_newline_after_table(&mut self, require: bool) {
         self.require_newline_after_table = require;
+    }
+
+    fn tables(&mut self) -> Result<Vec<Table<'a>>, Error> {
+        let mut tables = Vec::new();
+        let mut cur_table = Table {
+            at: 0,
+            header: Vec::new(),
+            values: None,
+            array: false,
+        };
+
+        while let Some(line) = self.line()? {
+            match line {
+                Line::Table {
+                    at,
+                    mut header,
+                    array,
+                } => {
+                    if !cur_table.header.is_empty() || cur_table.values.is_some() {
+                        tables.push(cur_table);
+                    }
+                    cur_table = Table {
+                        at: at,
+                        header: Vec::new(),
+                        values: Some(Vec::new()),
+                        array: array,
+                    };
+                    loop {
+                        let part = header.next().map_err(|e| self.token_error(e));
+                        match part? {
+                            Some(part) => cur_table.header.push(part),
+                            None => break,
+                        }
+                    }
+                }
+                Line::KeyValue(key, value) => {
+                    if cur_table.values.is_none() {
+                        cur_table.values = Some(Vec::new());
+                    }
+                    self.add_dotted_key(key, value, cur_table.values.as_mut().unwrap())?;
+                }
+            }
+        }
+        if !cur_table.header.is_empty() || cur_table.values.is_some() {
+            tables.push(cur_table);
+        }
+        Ok(tables)
     }
 
     fn line(&mut self) -> Result<Option<Line<'a>>, Error> {
@@ -1069,6 +1113,55 @@ impl<'a> Deserializer<'a> {
                 })
         } else {
             self.number(span, s)
+        }
+    }
+
+    /// Returns a string or table value type.
+    ///
+    /// Used to deserialize enums. Unit enums may be represented as a string or a table, all other
+    /// structures (tuple, newtype, struct) must be represented as a table.
+    fn string_or_table(&mut self) -> Result<(Value<'a>, Option<Cow<'a, str>>), Error> {
+        match self.peek()? {
+            Some((_, Token::LeftBracket)) => {
+                let tables = self.tables()?;
+                if tables.len() != 1 {
+                    return Err(Error::from_kind(ErrorKind::Wanted {
+                        expected: "exactly 1 table",
+                        found: if tables.is_empty() {
+                            "zero tables"
+                        } else {
+                            "more than 1 table"
+                        },
+                    }));
+                }
+
+                let table = tables
+                    .into_iter()
+                    .next()
+                    .expect("Expected exactly one table");
+                let header = table
+                    .header
+                    .last()
+                    .expect("Expected at least one header value for table.");
+
+                let start = table.at;
+                let end = table
+                    .values
+                    .as_ref()
+                    .and_then(|values| values.last())
+                    .map(|&(_, ref val)| val.end)
+                    .unwrap_or_else(|| header.len());
+                Ok((
+                    Value {
+                        e: E::DottedTable(table.values.unwrap_or_else(Vec::new)),
+                        start: start,
+                        end: end,
+                    },
+                    Some(header.clone()),
+                ))
+            }
+            Some(_) => self.value().map(|val| (val, None)),
+            None => Err(self.eof()),
         }
     }
 
@@ -1403,6 +1496,18 @@ impl<'a> Deserializer<'a> {
         Ok(result)
     }
 
+    /// Stores a value in the appropriate hierachical structure positioned based on the dotted key.
+    ///
+    /// Given the following definition: `multi.part.key = "value"`, `multi` and `part` are
+    /// intermediate parts which are mapped to the relevant fields in the deserialized type's data
+    /// hierarchy.
+    ///
+    /// # Parameters
+    ///
+    /// * `key_parts`: Each segment of the dotted key, e.g. `part.one` maps to
+    ///                `vec![Cow::Borrowed("part"), Cow::Borrowed("one")].`
+    /// * `value`: The parsed value.
+    /// * `values`: The `Vec` to store the value in.
     fn add_dotted_key(
         &self,
         mut key_parts: Vec<Cow<'a, str>>,
@@ -1430,12 +1535,12 @@ impl<'a> Deserializer<'a> {
             None => {}
         }
         // The start/end value is somewhat misleading here.
-        let inline_table = Value {
+        let table_values = Value {
             e: E::DottedTable(Vec::new()),
             start: value.start,
             end: value.end,
         };
-        values.push((key, inline_table));
+        values.push((key, table_values));
         let last_i = values.len() - 1;
         if let (
             _,
@@ -1634,7 +1739,6 @@ impl fmt::Display for Error {
             ErrorKind::EmptyTableKey => "empty table key found".fmt(f)?,
             ErrorKind::MultilineStringKey => "multiline strings are not allowed for key".fmt(f)?,
             ErrorKind::Custom => self.inner.message.fmt(f)?,
-            ErrorKind::ExpectedString => "expected string".fmt(f)?,
             ErrorKind::ExpectedTuple(l) => write!(f, "expected table with length {}", l)?,
             ErrorKind::ExpectedTupleIndex {
                 expected,
@@ -1687,7 +1791,6 @@ impl error::Error for Error {
             ErrorKind::EmptyTableKey => "empty table key found",
             ErrorKind::MultilineStringKey => "invalid multiline string for key",
             ErrorKind::Custom => "a custom error",
-            ErrorKind::ExpectedString => "expected string",
             ErrorKind::ExpectedTuple(_) => "expected table length",
             ErrorKind::ExpectedTupleIndex { .. } => "expected table key",
             ErrorKind::ExpectedEmptyTable => "expected empty table",

--- a/src/de.rs
+++ b/src/de.rs
@@ -164,6 +164,12 @@ enum ErrorKind {
     /// A struct was expected but something else was found
     ExpectedString,
 
+    /// A tuple with a certain number of elements was expected but something else was found
+    ExpectedTuple(usize),
+
+    /// An empty table was expected but entries were found
+    ExpectedEmptyTable,
+
     /// Dotted key attempted to extend something that is not a table.
     DottedKeyInvalidType,
 
@@ -791,7 +797,7 @@ impl<'de> de::EnumAccess<'de> for InlineTableDeserializer<'de> {
             None => {
                 return Err(Error::from_kind(ErrorKind::Wanted {
                     expected: "table with exactly 1 entry",
-                    found: "empty map",
+                    found: "empty table",
                 }))
             }
         };
@@ -806,8 +812,19 @@ impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
     type Error = Error;
 
     fn unit_variant(self) -> Result<(), Self::Error> {
-        // TODO: Error handling if there are entries
-        Ok(())
+        match self.next_value.expect("Expected value").e {
+            E::InlineTable(values) | E::DottedTable(values) => {
+                if values.len() == 0 {
+                    Ok(())
+                } else {
+                    Err(Error::from_kind(ErrorKind::ExpectedEmptyTable))
+                }
+            }
+            e @ _ => Err(Error::from_kind(ErrorKind::Wanted {
+                expected: "table",
+                found: e.type_name(),
+            })),
+        }
     }
 
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
@@ -819,11 +836,45 @@ impl<'de> de::VariantAccess<'de> for InlineTableDeserializer<'de> {
         ))
     }
 
-    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
     {
-        unimplemented!()
+        let next_value = self.next_value.expect("Expected value");
+        match next_value.e {
+            E::InlineTable(values) | E::DottedTable(values) => {
+                let tuple_values = values
+                    .into_iter()
+                    .enumerate()
+                    .filter_map(|(index, (key, value))| {
+                        // TODO: Is this expensive?
+                        if key == format!("{}", index) {
+                            Some(value)
+                        } else {
+                            // TODO: Err()
+                            unimplemented!()
+                        }
+                    })
+                    .collect::<Vec<_>>(); // TODO: is this expensive?
+
+                if tuple_values.len() == len {
+                    de::Deserializer::deserialize_seq(
+                        ValueDeserializer::new(Value {
+                            e: E::Array(tuple_values),
+                            start: next_value.start,
+                            end: next_value.end,
+                        }),
+                        visitor,
+                    )
+                } else {
+                    Err(Error::from_kind(ErrorKind::ExpectedTuple(len)))
+                }
+            }
+            e @ _ => Err(Error::from_kind(ErrorKind::Wanted {
+                expected: "table",
+                found: e.type_name(),
+            })),
+        }
     }
 
     fn struct_variant<V>(
@@ -1566,6 +1617,8 @@ impl fmt::Display for Error {
             ErrorKind::MultilineStringKey => "multiline strings are not allowed for key".fmt(f)?,
             ErrorKind::Custom => self.inner.message.fmt(f)?,
             ErrorKind::ExpectedString => "expected string".fmt(f)?,
+            ErrorKind::ExpectedTuple(l) => write!(f, "expected tuple with length {}", l)?,
+            ErrorKind::ExpectedEmptyTable => "expected empty table".fmt(f)?,
             ErrorKind::DottedKeyInvalidType => {
                 "dotted key attempted to extend non-table type".fmt(f)?
             }
@@ -1613,6 +1666,8 @@ impl error::Error for Error {
             ErrorKind::MultilineStringKey => "invalid multiline string for key",
             ErrorKind::Custom => "a custom error",
             ErrorKind::ExpectedString => "expected string",
+            ErrorKind::ExpectedTuple(_) => "expected tuple",
+            ErrorKind::ExpectedEmptyTable => "expected empty table",
             ErrorKind::DottedKeyInvalidType => "dotted key invalid type",
             ErrorKind::__Nonexhaustive => panic!(),
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -12,19 +12,20 @@ use std::str;
 use std::vec;
 
 use serde::de;
-use serde::de::IntoDeserializer;
 use serde::de::value::BorrowedStrDeserializer;
+use serde::de::IntoDeserializer;
 
-use tokens::{Tokenizer, Token, Error as TokenError, Span};
 use datetime;
 use spanned;
+use tokens::{Error as TokenError, Span, Token, Tokenizer};
 
 /// Deserializes a byte slice into a type.
 ///
 /// This function will attempt to interpret `bytes` as UTF-8 data and then
 /// deserialize `T` from the TOML document provided.
 pub fn from_slice<'de, T>(bytes: &'de [u8]) -> Result<T, Error>
-    where T: de::Deserialize<'de>,
+where
+    T: de::Deserialize<'de>,
 {
     match str::from_utf8(bytes) {
         Ok(s) => from_str(s),
@@ -68,7 +69,8 @@ pub fn from_slice<'de, T>(bytes: &'de [u8]) -> Result<T, Error>
 /// }
 /// ```
 pub fn from_str<'de, T>(s: &'de str) -> Result<T, Error>
-    where T: de::Deserialize<'de>,
+where
+    T: de::Deserialize<'de>,
 {
     let mut d = Deserializer::new(s);
     let ret = T::deserialize(&mut d)?;
@@ -180,7 +182,8 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         let mut tables = Vec::new();
         let mut cur_table = Table {
@@ -192,7 +195,11 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
 
         while let Some(line) = self.line()? {
             match line {
-                Line::Table { at, mut header, array } => {
+                Line::Table {
+                    at,
+                    mut header,
+                    array,
+                } => {
                     if !cur_table.header.is_empty() || cur_table.values.is_some() {
                         tables.push(cur_table);
                     }
@@ -203,9 +210,7 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
                         array: array,
                     };
                     loop {
-                        let part = header.next().map_err(|e| {
-                            self.token_error(e)
-                        });
+                        let part = header.next().map_err(|e| self.token_error(e));
                         match part? {
                             Some(part) => cur_table.header.push(part),
                             None => break,
@@ -241,16 +246,15 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
         self,
         _name: &'static str,
         _variants: &'static [&'static str],
-        visitor: V
+        visitor: V,
     ) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         if let Some(next) = self.next()? {
             match next {
-                (_, Token::String { val, .. }) => {
-                    visitor.visit_enum(val.into_deserializer())
-                },
-                _ => Err(Error::from_kind(ErrorKind::ExpectedString))
+                (_, Token::String { val, .. }) => visitor.visit_enum(val.into_deserializer()),
+                _ => Err(Error::from_kind(ErrorKind::ExpectedString)),
             }
         } else {
             Err(Error::from_kind(ErrorKind::UnexpectedEof))
@@ -288,10 +292,11 @@ impl<'de, 'b> de::MapAccess<'de> for MapVisitor<'de, 'b> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
-        where K: de::DeserializeSeed<'de>,
+    where
+        K: de::DeserializeSeed<'de>,
     {
         if self.cur_parent == self.max || self.cur == self.max {
-            return Ok(None)
+            return Ok(None);
         }
 
         loop {
@@ -299,20 +304,24 @@ impl<'de, 'b> de::MapAccess<'de> for MapVisitor<'de, 'b> {
             if let Some((key, value)) = self.values.next() {
                 let ret = seed.deserialize(StrDeserializer::new(key.clone()))?;
                 self.next_value = Some((key, value));
-                return Ok(Some(ret))
+                return Ok(Some(ret));
             }
 
             let next_table = {
                 let prefix = &self.tables[self.cur_parent].header[..self.depth];
-                self.tables[self.cur..self.max].iter().enumerate().find(|&(_, t)| {
-                    if t.values.is_none() {
-                        return false
-                    }
-                    match t.header.get(..self.depth) {
-                        Some(header) => header == prefix,
-                        None => false,
-                    }
-                }).map(|(i, _)| i + self.cur)
+                self.tables[self.cur..self.max]
+                    .iter()
+                    .enumerate()
+                    .find(|&(_, t)| {
+                        if t.values.is_none() {
+                            return false;
+                        }
+                        match t.header.get(..self.depth) {
+                            Some(header) => header == prefix,
+                            None => false,
+                        }
+                    })
+                    .map(|(i, _)| i + self.cur)
             };
 
             let pos = match next_table {
@@ -323,11 +332,12 @@ impl<'de, 'b> de::MapAccess<'de> for MapVisitor<'de, 'b> {
 
             // Test to see if we're duplicating our parent's table, and if so
             // then this is an error in the toml format
-            if self.cur_parent != pos &&
-               self.tables[self.cur_parent].header == self.tables[pos].header {
+            if self.cur_parent != pos
+                && self.tables[self.cur_parent].header == self.tables[pos].header
+            {
                 let at = self.tables[pos].at;
                 let name = self.tables[pos].header.join(".");
-                return Err(self.de.error(at, ErrorKind::DuplicateTable(name)))
+                return Err(self.de.error(at, ErrorKind::DuplicateTable(name)));
             }
 
             let table = &mut self.tables[pos];
@@ -338,42 +348,47 @@ impl<'de, 'b> de::MapAccess<'de> for MapVisitor<'de, 'b> {
             if self.depth != table.header.len() {
                 let key = &table.header[self.depth];
                 let key = seed.deserialize(StrDeserializer::new(key.clone()))?;
-                return Ok(Some(key))
+                return Ok(Some(key));
             }
 
             // Rule out cases like:
             //
             //      [[foo.bar]]
             //      [[foo]]
-            if table.array  {
+            if table.array {
                 let kind = ErrorKind::RedefineAsArray;
-                return Err(self.de.error(table.at, kind))
+                return Err(self.de.error(table.at, kind));
             }
 
-            self.values = table.values.take().expect("Unable to read table values").into_iter();
+            self.values = table
+                .values
+                .take()
+                .expect("Unable to read table values")
+                .into_iter();
         }
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
-        where V: de::DeserializeSeed<'de>,
+    where
+        V: de::DeserializeSeed<'de>,
     {
         if let Some((k, v)) = self.next_value.take() {
             match seed.deserialize(ValueDeserializer::new(v)) {
                 Ok(v) => return Ok(v),
                 Err(mut e) => {
                     e.add_key_context(&k);
-                    return Err(e)
+                    return Err(e);
                 }
             }
         }
 
-        let array = self.tables[self.cur].array &&
-                    self.depth == self.tables[self.cur].header.len() - 1;
+        let array =
+            self.tables[self.cur].array && self.depth == self.tables[self.cur].header.len() - 1;
         self.cur += 1;
         let res = seed.deserialize(MapVisitor {
             values: Vec::new().into_iter(),
             next_value: None,
-            depth: self.depth + if array {0} else {1},
+            depth: self.depth + if array { 0 } else { 1 },
             cur_parent: self.cur - 1,
             cur: 0,
             max: self.max,
@@ -392,26 +407,30 @@ impl<'de, 'b> de::SeqAccess<'de> for MapVisitor<'de, 'b> {
     type Error = Error;
 
     fn next_element_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
-        where K: de::DeserializeSeed<'de>,
+    where
+        K: de::DeserializeSeed<'de>,
     {
         assert!(self.next_value.is_none());
         assert!(self.values.next().is_none());
 
         if self.cur_parent == self.max {
-            return Ok(None)
+            return Ok(None);
         }
 
         let next = self.tables[..self.max]
             .iter()
             .enumerate()
             .skip(self.cur_parent + 1)
-            .find(|&(_, table)| {
-                table.array && table.header == self.tables[self.cur_parent].header
-            }).map(|p| p.0)
+            .find(|&(_, table)| table.array && table.header == self.tables[self.cur_parent].header)
+            .map(|p| p.0)
             .unwrap_or(self.max);
 
         let ret = seed.deserialize(MapVisitor {
-            values: self.tables[self.cur_parent].values.take().expect("Unable to read table values").into_iter(),
+            values: self.tables[self.cur_parent]
+                .values
+                .take()
+                .expect("Unable to read table values")
+                .into_iter(),
             next_value: None,
             depth: self.depth + 1,
             cur_parent: self.cur_parent,
@@ -430,9 +449,10 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
-        if self.array  {
+        if self.array {
             visitor.visit_seq(self)
         } else {
             visitor.visit_map(self)
@@ -442,7 +462,8 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     // `None` is interpreted as a missing field so be sure to implement `Some`
     // as a present field.
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         visitor.visit_some(self)
     }
@@ -450,9 +471,10 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     fn deserialize_newtype_struct<V>(
         self,
         _name: &'static str,
-        visitor: V
+        visitor: V,
     ) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
     }
@@ -470,9 +492,7 @@ struct StrDeserializer<'a> {
 
 impl<'a> StrDeserializer<'a> {
     fn new(key: Cow<'a, str>) -> StrDeserializer<'a> {
-        StrDeserializer {
-            key: key,
-        }
+        StrDeserializer { key: key }
     }
 }
 
@@ -480,7 +500,8 @@ impl<'de> de::Deserializer<'de> for StrDeserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         match self.key {
             Cow::Borrowed(s) => visitor.visit_borrowed_str(s),
@@ -501,9 +522,7 @@ struct ValueDeserializer<'a> {
 
 impl<'a> ValueDeserializer<'a> {
     fn new(value: Value<'a>) -> ValueDeserializer<'a> {
-        ValueDeserializer {
-            value: value,
-        }
+        ValueDeserializer { value: value }
     }
 }
 
@@ -511,7 +530,8 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         match self.value.e {
             E::Integer(i) => visitor.visit_i64(i),
@@ -538,18 +558,21 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
         }
     }
 
-    fn deserialize_struct<V>(self,
-                             name: &'static str,
-                             fields: &'static [&'static str],
-                             visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
     {
         if name == datetime::NAME && fields == &[datetime::FIELD] {
             if let E::Datetime(s) = self.value.e {
                 return visitor.visit_map(DatetimeDeserializer {
                     date: s,
                     visited: false,
-                })
+                });
             }
         }
 
@@ -570,7 +593,8 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
     // `None` is interpreted as a missing field so be sure to implement `Some`
     // as a present field.
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         visitor.visit_some(self)
     }
@@ -579,22 +603,24 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
         self,
         _name: &'static str,
         _variants: &'static [&'static str],
-        visitor: V
+        visitor: V,
     ) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         match self.value.e {
             E::String(val) => visitor.visit_enum(val.into_deserializer()),
-            _ => Err(Error::from_kind(ErrorKind::ExpectedString))
+            _ => Err(Error::from_kind(ErrorKind::ExpectedString)),
         }
     }
 
     fn deserialize_newtype_struct<V>(
         self,
         _name: &'static str,
-        visitor: V
+        visitor: V,
     ) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>
+    where
+        V: de::Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
     }
@@ -628,11 +654,14 @@ impl<'de> de::MapAccess<'de> for SpannedDeserializer<'de> {
         K: de::DeserializeSeed<'de>,
     {
         if self.start.is_some() {
-            seed.deserialize(BorrowedStrDeserializer::new(spanned::START)).map(Some)
+            seed.deserialize(BorrowedStrDeserializer::new(spanned::START))
+                .map(Some)
         } else if self.end.is_some() {
-            seed.deserialize(BorrowedStrDeserializer::new(spanned::END)).map(Some)
+            seed.deserialize(BorrowedStrDeserializer::new(spanned::END))
+                .map(Some)
         } else if self.value.is_some() {
-            seed.deserialize(BorrowedStrDeserializer::new(spanned::VALUE)).map(Some)
+            seed.deserialize(BorrowedStrDeserializer::new(spanned::VALUE))
+                .map(Some)
         } else {
             Ok(None)
         }
@@ -644,7 +673,7 @@ impl<'de> de::MapAccess<'de> for SpannedDeserializer<'de> {
     {
         if let Some(start) = self.start.take() {
             seed.deserialize(start.into_deserializer())
-        } else if  let Some(end) = self.end.take() {
+        } else if let Some(end) = self.end.take() {
             seed.deserialize(end.into_deserializer())
         } else if let Some(value) = self.value.take() {
             seed.deserialize(value.into_deserializer())
@@ -663,17 +692,19 @@ impl<'de> de::MapAccess<'de> for DatetimeDeserializer<'de> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
-        where K: de::DeserializeSeed<'de>,
+    where
+        K: de::DeserializeSeed<'de>,
     {
         if self.visited {
-            return Ok(None)
+            return Ok(None);
         }
         self.visited = true;
         seed.deserialize(DatetimeFieldDeserializer).map(Some)
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
-        where V: de::DeserializeSeed<'de>,
+    where
+        V: de::DeserializeSeed<'de>,
     {
         seed.deserialize(StrDeserializer::new(self.date.into()))
     }
@@ -685,7 +716,8 @@ impl<'de> de::Deserializer<'de> for DatetimeFieldDeserializer {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         visitor.visit_borrowed_str(datetime::FIELD)
     }
@@ -706,7 +738,8 @@ impl<'de> de::MapAccess<'de> for InlineTableDeserializer<'de> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
-        where K: de::DeserializeSeed<'de>,
+    where
+        K: de::DeserializeSeed<'de>,
     {
         let (key, value) = match self.values.next() {
             Some(pair) => pair,
@@ -717,13 +750,13 @@ impl<'de> de::MapAccess<'de> for InlineTableDeserializer<'de> {
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
-        where V: de::DeserializeSeed<'de>,
+    where
+        V: de::DeserializeSeed<'de>,
     {
         let value = self.next_value.take().expect("Unable to read table values");
         seed.deserialize(ValueDeserializer::new(value))
     }
 }
-
 
 impl<'a> Deserializer<'a> {
     /// Creates a new deserializer which will be deserializing the string
@@ -758,12 +791,12 @@ impl<'a> Deserializer<'a> {
         loop {
             self.eat_whitespace()?;
             if self.eat_comment()? {
-                continue
+                continue;
             }
             if self.eat(Token::Newline)? {
-                continue
+                continue;
             }
-            break
+            break;
         }
 
         match self.peek()? {
@@ -777,9 +810,7 @@ impl<'a> Deserializer<'a> {
         let start = self.tokens.current();
         self.expect(Token::LeftBracket)?;
         let array = self.eat(Token::LeftBracket)?;
-        let ret = Header::new(self.tokens.clone(),
-                              array,
-                              self.require_newline_after_table);
+        let ret = Header::new(self.tokens.clone(), array, self.require_newline_after_table);
         if self.require_newline_after_table {
             self.tokens.skip_to_newline();
         } else {
@@ -789,16 +820,19 @@ impl<'a> Deserializer<'a> {
                         if array {
                             self.eat(Token::RightBracket)?;
                         }
-                        break
+                        break;
                     }
-                    Some((_, Token::Newline)) |
-                    None => break,
+                    Some((_, Token::Newline)) | None => break,
                     _ => {}
                 }
             }
             self.eat_whitespace()?;
         }
-        Ok(Line::Table { at: start, header: ret, array: array })
+        Ok(Line::Table {
+            at: start,
+            header: ret,
+            array: array,
+        })
     }
 
     fn key_value(&mut self) -> Result<Line<'a>, Error> {
@@ -819,65 +853,77 @@ impl<'a> Deserializer<'a> {
     fn value(&mut self) -> Result<Value<'a>, Error> {
         let at = self.tokens.current();
         let value = match self.next()? {
-            Some((Span { start, end }, Token::String { val, .. })) => {
-                Value { e: E::String(val), start: start, end: end }
-            }
-            Some((Span { start, end }, Token::Keylike("true"))) => {
-                Value { e: E::Boolean(true), start: start, end: end }
-            }
-            Some((Span { start, end }, Token::Keylike("false"))) => {
-                Value { e: E::Boolean(false), start: start, end: end }
-            }
+            Some((Span { start, end }, Token::String { val, .. })) => Value {
+                e: E::String(val),
+                start: start,
+                end: end,
+            },
+            Some((Span { start, end }, Token::Keylike("true"))) => Value {
+                e: E::Boolean(true),
+                start: start,
+                end: end,
+            },
+            Some((Span { start, end }, Token::Keylike("false"))) => Value {
+                e: E::Boolean(false),
+                start: start,
+                end: end,
+            },
             Some((span, Token::Keylike(key))) => self.number_or_date(span, key)?,
             Some((span, Token::Plus)) => self.number_leading_plus(span)?,
             Some((Span { start, .. }, Token::LeftBrace)) => {
                 self.inline_table().map(|(Span { end, .. }, table)| Value {
                     e: E::InlineTable(table),
                     start: start,
-                    end: end
+                    end: end,
                 })?
             }
             Some((Span { start, .. }, Token::LeftBracket)) => {
                 self.array().map(|(Span { end, .. }, array)| Value {
                     e: E::Array(array),
                     start: start,
-                    end: end
+                    end: end,
                 })?
             }
             Some(token) => {
-                return Err(self.error(at, ErrorKind::Wanted {
-                    expected: "a value",
-                    found: token.1.describe(),
-                }))
+                return Err(self.error(
+                    at,
+                    ErrorKind::Wanted {
+                        expected: "a value",
+                        found: token.1.describe(),
+                    },
+                ))
             }
             None => return Err(self.eof()),
         };
         Ok(value)
     }
 
-    fn number_or_date(&mut self, span: Span, s: &'a str)
-        -> Result<Value<'a>, Error>
-    {
-        if s.contains('T') || (s.len() > 1 && s[1..].contains('-')) &&
-           !s.contains("e-") {
-            self.datetime(span, s, false).map(|(Span { start, end }, d)| Value {
-                e: E::Datetime(d),
-                start: start,
-                end: end
-            })
+    fn number_or_date(&mut self, span: Span, s: &'a str) -> Result<Value<'a>, Error> {
+        if s.contains('T') || (s.len() > 1 && s[1..].contains('-')) && !s.contains("e-") {
+            self.datetime(span, s, false)
+                .map(|(Span { start, end }, d)| Value {
+                    e: E::Datetime(d),
+                    start: start,
+                    end: end,
+                })
         } else if self.eat(Token::Colon)? {
-            self.datetime(span, s, true).map(|(Span { start, end }, d)| Value {
-                e: E::Datetime(d),
-                start: start,
-                end: end
-            })
+            self.datetime(span, s, true)
+                .map(|(Span { start, end }, d)| Value {
+                    e: E::Datetime(d),
+                    start: start,
+                    end: end,
+                })
         } else {
             self.number(span, s)
         }
     }
 
-    fn number(&mut self, Span { start, end}: Span, s: &'a str) -> Result<Value<'a>, Error> {
-        let to_integer = |f| Value { e: E::Integer(f), start: start, end: end };
+    fn number(&mut self, Span { start, end }: Span, s: &'a str) -> Result<Value<'a>, Error> {
+        let to_integer = |f| Value {
+            e: E::Integer(f),
+            start: start,
+            end: end,
+        };
         if s.starts_with("0x") {
             self.integer(&s[2..], 16).map(to_integer)
         } else if s.starts_with("0o") {
@@ -885,25 +931,47 @@ impl<'a> Deserializer<'a> {
         } else if s.starts_with("0b") {
             self.integer(&s[2..], 2).map(to_integer)
         } else if s.contains('e') || s.contains('E') {
-            self.float(s, None).map(|f| Value { e: E::Float(f), start: start, end: end })
+            self.float(s, None).map(|f| Value {
+                e: E::Float(f),
+                start: start,
+                end: end,
+            })
         } else if self.eat(Token::Period)? {
             let at = self.tokens.current();
             match self.next()? {
                 Some((Span { start, end }, Token::Keylike(after))) => {
                     self.float(s, Some(after)).map(|f| Value {
-                        e: E::Float(f), start: start, end: end
+                        e: E::Float(f),
+                        start: start,
+                        end: end,
                     })
                 }
                 _ => Err(self.error(at, ErrorKind::NumberInvalid)),
             }
         } else if s == "inf" {
-            Ok(Value { e: E::Float(f64::INFINITY), start: start, end: end })
+            Ok(Value {
+                e: E::Float(f64::INFINITY),
+                start: start,
+                end: end,
+            })
         } else if s == "-inf" {
-            Ok(Value { e: E::Float(f64::NEG_INFINITY), start: start, end: end })
+            Ok(Value {
+                e: E::Float(f64::NEG_INFINITY),
+                start: start,
+                end: end,
+            })
         } else if s == "nan" {
-            Ok(Value { e: E::Float(f64::NAN), start: start, end: end })
+            Ok(Value {
+                e: E::Float(f64::NAN),
+                start: start,
+                end: end,
+            })
         } else if s == "-nan" {
-            Ok(Value { e: E::Float(-f64::NAN), start: start, end: end })
+            Ok(Value {
+                e: E::Float(-f64::NAN),
+                start: start,
+                end: end,
+            })
         } else {
             self.integer(s, 10).map(to_integer)
         }
@@ -912,9 +980,13 @@ impl<'a> Deserializer<'a> {
     fn number_leading_plus(&mut self, Span { start, .. }: Span) -> Result<Value<'a>, Error> {
         let start_token = self.tokens.current();
         match self.next()? {
-            Some((Span { end, .. }, Token::Keylike(s))) => {
-                self.number(Span { start: start, end: end }, s)
-            },
+            Some((Span { end, .. }, Token::Keylike(s))) => self.number(
+                Span {
+                    start: start,
+                    end: end,
+                },
+                s,
+            ),
             _ => Err(self.error(start_token, ErrorKind::NumberInvalid)),
         }
     }
@@ -925,7 +997,7 @@ impl<'a> Deserializer<'a> {
         let (prefix, suffix) = self.parse_integer(s, allow_sign, allow_leading_zeros, radix)?;
         let start = self.tokens.substr_offset(s);
         if suffix != "" {
-            return Err(self.error(start, ErrorKind::NumberInvalid))
+            return Err(self.error(start, ErrorKind::NumberInvalid));
         }
         i64::from_str_radix(&prefix.replace("_", "").trim_left_matches('+'), radix)
             .map_err(|_e| self.error(start, ErrorKind::NumberInvalid))
@@ -947,7 +1019,7 @@ impl<'a> Deserializer<'a> {
         for (i, c) in s.char_indices() {
             let at = i + start;
             if i == 0 && (c == '+' || c == '-') && allow_sign {
-                continue
+                continue;
             }
 
             if c == '0' && first {
@@ -968,20 +1040,19 @@ impl<'a> Deserializer<'a> {
             first = false;
         }
         if first || underscore {
-            return Err(self.error(start, ErrorKind::NumberInvalid))
+            return Err(self.error(start, ErrorKind::NumberInvalid));
         }
         Ok((&s[..end], &s[end..]))
     }
 
-    fn float(&mut self, s: &'a str, after_decimal: Option<&'a str>)
-             -> Result<f64, Error> {
+    fn float(&mut self, s: &'a str, after_decimal: Option<&'a str>) -> Result<f64, Error> {
         let (integral, mut suffix) = self.parse_integer(s, true, false, 10)?;
         let start = self.tokens.substr_offset(integral);
 
         let mut fraction = None;
         if let Some(after) = after_decimal {
             if suffix != "" {
-                return Err(self.error(start, ErrorKind::NumberInvalid))
+                return Err(self.error(start, ErrorKind::NumberInvalid));
             }
             let (a, b) = self.parse_integer(after, false, true, 10)?;
             fraction = Some(a);
@@ -993,24 +1064,23 @@ impl<'a> Deserializer<'a> {
             let (a, b) = if suffix.len() == 1 {
                 self.eat(Token::Plus)?;
                 match self.next()? {
-                    Some((_, Token::Keylike(s))) => {
-                        self.parse_integer(s, false, false, 10)?
-                    }
+                    Some((_, Token::Keylike(s))) => self.parse_integer(s, false, false, 10)?,
                     _ => return Err(self.error(start, ErrorKind::NumberInvalid)),
                 }
             } else {
                 self.parse_integer(&suffix[1..], true, false, 10)?
             };
             if b != "" {
-                return Err(self.error(start, ErrorKind::NumberInvalid))
+                return Err(self.error(start, ErrorKind::NumberInvalid));
             }
             exponent = Some(a);
         }
 
-        let mut number = integral.trim_left_matches('+')
-                                 .chars()
-                                 .filter(|c| *c != '_')
-                                 .collect::<String>();
+        let mut number = integral
+            .trim_left_matches('+')
+            .chars()
+            .filter(|c| *c != '_')
+            .collect::<String>();
         if let Some(fraction) = fraction {
             number.push_str(".");
             number.extend(fraction.chars().filter(|c| *c != '_'));
@@ -1019,19 +1089,24 @@ impl<'a> Deserializer<'a> {
             number.push_str("E");
             number.extend(exponent.chars().filter(|c| *c != '_'));
         }
-        number.parse().map_err(|_e| {
-            self.error(start, ErrorKind::NumberInvalid)
-        }).and_then(|n: f64| {
-            if n.is_finite() {
-                Ok(n)
-            } else {
-                Err(self.error(start, ErrorKind::NumberInvalid))
-            }
-        })
+        number
+            .parse()
+            .map_err(|_e| self.error(start, ErrorKind::NumberInvalid))
+            .and_then(|n: f64| {
+                if n.is_finite() {
+                    Ok(n)
+                } else {
+                    Err(self.error(start, ErrorKind::NumberInvalid))
+                }
+            })
     }
 
-    fn datetime(&mut self, mut span: Span, date: &'a str, colon_eaten: bool)
-                -> Result<(Span, &'a str), Error> {
+    fn datetime(
+        &mut self,
+        mut span: Span,
+        date: &'a str,
+        colon_eaten: bool,
+    ) -> Result<(Span, &'a str), Error> {
         let start = self.tokens.substr_offset(date);
 
         // Check for space separated date and time.
@@ -1056,7 +1131,7 @@ impl<'a> Deserializer<'a> {
             match self.next()? {
                 Some((Span { end, .. }, Token::Keylike(_))) => {
                     span.end = end;
-                },
+                }
                 _ => return Err(self.error(start, ErrorKind::DateInvalid)),
             }
             // Fractional seconds
@@ -1064,7 +1139,7 @@ impl<'a> Deserializer<'a> {
                 match self.next()? {
                     Some((Span { end, .. }, Token::Keylike(_))) => {
                         span.end = end;
-                    },
+                    }
                     _ => return Err(self.error(start, ErrorKind::DateInvalid)),
                 }
             }
@@ -1074,7 +1149,7 @@ impl<'a> Deserializer<'a> {
                 match self.next()? {
                     Some((Span { end, .. }, Token::Keylike(_))) => {
                         span.end = end;
-                    },
+                    }
                     _ => return Err(self.error(start, ErrorKind::DateInvalid)),
                 }
             }
@@ -1082,7 +1157,7 @@ impl<'a> Deserializer<'a> {
                 match self.next()? {
                     Some((Span { end, .. }, Token::Keylike(_))) => {
                         span.end = end;
-                    },
+                    }
                     _ => return Err(self.error(start, ErrorKind::DateInvalid)),
                 }
             }
@@ -1098,7 +1173,7 @@ impl<'a> Deserializer<'a> {
         let mut ret = Vec::new();
         self.eat_whitespace()?;
         if let Some(span) = self.eat_spanned(Token::RightBrace)? {
-            return Ok((span, ret))
+            return Ok((span, ret));
         }
         loop {
             let key = self.dotted_key()?;
@@ -1110,7 +1185,7 @@ impl<'a> Deserializer<'a> {
 
             self.eat_whitespace()?;
             if let Some(span) = self.eat_spanned(Token::RightBrace)? {
-                return Ok((span, ret))
+                return Ok((span, ret));
             }
             self.expect(Token::Comma)?;
             self.eat_whitespace()?;
@@ -1126,7 +1201,7 @@ impl<'a> Deserializer<'a> {
             loop {
                 me.eat_whitespace()?;
                 if !me.eat(Token::Newline)? && !me.eat_comment()? {
-                    break
+                    break;
                 }
             }
             Ok(())
@@ -1135,19 +1210,19 @@ impl<'a> Deserializer<'a> {
         loop {
             intermediate(self)?;
             if let Some(span) = self.eat_spanned(Token::RightBracket)? {
-                return Ok((span, ret))
+                return Ok((span, ret));
             }
             let at = self.tokens.current();
             let value = self.value()?;
             if let Some(last) = ret.last() {
                 if !value.same_type(last) {
-                    return Err(self.error(at, ErrorKind::MixedArrayType))
+                    return Err(self.error(at, ErrorKind::MixedArrayType));
                 }
             }
             ret.push(value);
             intermediate(self)?;
             if !self.eat(Token::Comma)? {
-                break
+                break;
             }
         }
         intermediate(self)?;
@@ -1156,7 +1231,10 @@ impl<'a> Deserializer<'a> {
     }
 
     fn table_key(&mut self) -> Result<Cow<'a, str>, Error> {
-        self.tokens.table_key().map(|t| t.1).map_err(|e| self.token_error(e))
+        self.tokens
+            .table_key()
+            .map(|t| t.1)
+            .map_err(|e| self.token_error(e))
     }
 
     fn dotted_key(&mut self) -> Result<Vec<Cow<'a, str>>, Error> {
@@ -1183,7 +1261,13 @@ impl<'a> Deserializer<'a> {
             return Ok(());
         }
         match values.iter_mut().find(|&&mut (ref k, _)| *k == key) {
-            Some(&mut (_, Value { e: E::DottedTable(ref mut v), .. })) => {
+            Some(&mut (
+                _,
+                Value {
+                    e: E::DottedTable(ref mut v),
+                    ..
+                },
+            )) => {
                 return self.add_dotted_key(key_parts, value, v);
             }
             Some(&mut (_, Value { start, .. })) => {
@@ -1199,14 +1283,23 @@ impl<'a> Deserializer<'a> {
         };
         values.push((key, inline_table));
         let last_i = values.len() - 1;
-        if let (_, Value { e: E::DottedTable(ref mut v), .. }) = values[last_i] {
+        if let (
+            _,
+            Value {
+                e: E::DottedTable(ref mut v),
+                ..
+            },
+        ) = values[last_i]
+        {
             self.add_dotted_key(key_parts, value, v)?;
         }
         Ok(())
     }
 
     fn eat_whitespace(&mut self) -> Result<(), Error> {
-        self.tokens.eat_whitespace().map_err(|e| self.token_error(e))
+        self.tokens
+            .eat_whitespace()
+            .map_err(|e| self.token_error(e))
     }
 
     fn eat_comment(&mut self) -> Result<bool, Error> {
@@ -1214,7 +1307,9 @@ impl<'a> Deserializer<'a> {
     }
 
     fn eat_newline_or_eof(&mut self) -> Result<(), Error> {
-        self.tokens.eat_newline_or_eof().map_err(|e| self.token_error(e))
+        self.tokens
+            .eat_newline_or_eof()
+            .map_err(|e| self.token_error(e))
     }
 
     fn eat(&mut self, expected: Token<'a>) -> Result<bool, Error> {
@@ -1222,15 +1317,21 @@ impl<'a> Deserializer<'a> {
     }
 
     fn eat_spanned(&mut self, expected: Token<'a>) -> Result<Option<Span>, Error> {
-        self.tokens.eat_spanned(expected).map_err(|e| self.token_error(e))
+        self.tokens
+            .eat_spanned(expected)
+            .map_err(|e| self.token_error(e))
     }
 
     fn expect(&mut self, expected: Token<'a>) -> Result<(), Error> {
-        self.tokens.expect(expected).map_err(|e| self.token_error(e))
+        self.tokens
+            .expect(expected)
+            .map_err(|e| self.token_error(e))
     }
 
     fn expect_spanned(&mut self, expected: Token<'a>) -> Result<Span, Error> {
-        self.tokens.expect_spanned(expected).map_err(|e| self.token_error(e))
+        self.tokens
+            .expect_spanned(expected)
+            .map_err(|e| self.token_error(e))
     }
 
     fn next(&mut self) -> Result<Option<(Span, Token<'a>)>, Error> {
@@ -1250,36 +1351,28 @@ impl<'a> Deserializer<'a> {
             TokenError::InvalidCharInString(at, ch) => {
                 self.error(at, ErrorKind::InvalidCharInString(ch))
             }
-            TokenError::InvalidEscape(at, ch) => {
-                self.error(at, ErrorKind::InvalidEscape(ch))
-            }
+            TokenError::InvalidEscape(at, ch) => self.error(at, ErrorKind::InvalidEscape(ch)),
             TokenError::InvalidEscapeValue(at, v) => {
                 self.error(at, ErrorKind::InvalidEscapeValue(v))
             }
-            TokenError::InvalidHexEscape(at, ch) => {
-                self.error(at, ErrorKind::InvalidHexEscape(ch))
-            }
-            TokenError::NewlineInString(at) => {
-                self.error(at, ErrorKind::NewlineInString)
-            }
-            TokenError::Unexpected(at, ch) => {
-                self.error(at, ErrorKind::Unexpected(ch))
-            }
-            TokenError::UnterminatedString(at) => {
-                self.error(at, ErrorKind::UnterminatedString)
-            }
-            TokenError::NewlineInTableKey(at) => {
-                self.error(at, ErrorKind::NewlineInTableKey)
-            }
-            TokenError::Wanted { at, expected, found } => {
-                self.error(at, ErrorKind::Wanted { expected: expected, found: found })
-            }
-            TokenError::EmptyTableKey(at) => {
-                self.error(at, ErrorKind::EmptyTableKey)
-            }
-            TokenError::MultilineStringKey(at) => {
-                self.error(at, ErrorKind::MultilineStringKey)
-            }
+            TokenError::InvalidHexEscape(at, ch) => self.error(at, ErrorKind::InvalidHexEscape(ch)),
+            TokenError::NewlineInString(at) => self.error(at, ErrorKind::NewlineInString),
+            TokenError::Unexpected(at, ch) => self.error(at, ErrorKind::Unexpected(ch)),
+            TokenError::UnterminatedString(at) => self.error(at, ErrorKind::UnterminatedString),
+            TokenError::NewlineInTableKey(at) => self.error(at, ErrorKind::NewlineInTableKey),
+            TokenError::Wanted {
+                at,
+                expected,
+                found,
+            } => self.error(
+                at,
+                ErrorKind::Wanted {
+                    expected: expected,
+                    found: found,
+                },
+            ),
+            TokenError::EmptyTableKey(at) => self.error(at, ErrorKind::EmptyTableKey),
+            TokenError::MultilineStringKey(at) => self.error(at, ErrorKind::MultilineStringKey),
         }
     }
 
@@ -1298,7 +1391,7 @@ impl<'a> Deserializer<'a> {
         let mut cur = 0;
         for (i, line) in self.input.lines().enumerate() {
             if cur + line.len() + 1 > offset {
-                return (i, offset - cur)
+                return (i, offset - cur);
             }
             cur += line.len() + 1;
         }
@@ -1350,26 +1443,28 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.inner.kind {
             ErrorKind::UnexpectedEof => "unexpected eof encountered".fmt(f)?,
-            ErrorKind::InvalidCharInString(c) => {
-                write!(f, "invalid character in string: `{}`",
-                       c.escape_default().collect::<String>())?
-            }
-            ErrorKind::InvalidEscape(c) => {
-                write!(f, "invalid escape character in string: `{}`",
-                       c.escape_default().collect::<String>())?
-            }
-            ErrorKind::InvalidHexEscape(c) => {
-                write!(f, "invalid hex escape character in string: `{}`",
-                       c.escape_default().collect::<String>())?
-            }
-            ErrorKind::InvalidEscapeValue(c) => {
-                write!(f, "invalid escape value: `{}`", c)?
-            }
+            ErrorKind::InvalidCharInString(c) => write!(
+                f,
+                "invalid character in string: `{}`",
+                c.escape_default().collect::<String>()
+            )?,
+            ErrorKind::InvalidEscape(c) => write!(
+                f,
+                "invalid escape character in string: `{}`",
+                c.escape_default().collect::<String>()
+            )?,
+            ErrorKind::InvalidHexEscape(c) => write!(
+                f,
+                "invalid hex escape character in string: `{}`",
+                c.escape_default().collect::<String>()
+            )?,
+            ErrorKind::InvalidEscapeValue(c) => write!(f, "invalid escape value: `{}`", c)?,
             ErrorKind::NewlineInString => "newline in string found".fmt(f)?,
-            ErrorKind::Unexpected(ch) => {
-                write!(f, "unexpected character found: `{}`",
-                       ch.escape_default().collect::<String>())?
-            }
+            ErrorKind::Unexpected(ch) => write!(
+                f,
+                "unexpected character found: `{}`",
+                ch.escape_default().collect::<String>()
+            )?,
             ErrorKind::UnterminatedString => "unterminated string".fmt(f)?,
             ErrorKind::NewlineInTableKey => "found newline in table key".fmt(f)?,
             ErrorKind::Wanted { expected, found } => {
@@ -1386,7 +1481,9 @@ impl fmt::Display for Error {
             ErrorKind::MultilineStringKey => "multiline strings are not allowed for key".fmt(f)?,
             ErrorKind::Custom => self.inner.message.fmt(f)?,
             ErrorKind::ExpectedString => "expected string".fmt(f)?,
-            ErrorKind::DottedKeyInvalidType => "dotted key attempted to extend non-table type".fmt(f)?,
+            ErrorKind::DottedKeyInvalidType => {
+                "dotted key attempted to extend non-table type".fmt(f)?
+            }
             ErrorKind::__Nonexhaustive => panic!(),
         }
 
@@ -1444,7 +1541,11 @@ impl de::Error for Error {
 }
 
 enum Line<'a> {
-    Table { at: usize, header: Header<'a>, array: bool },
+    Table {
+        at: usize,
+        header: Header<'a>,
+        array: bool,
+    },
     KeyValue(Vec<Cow<'a, str>>, Value<'a>),
 }
 
@@ -1456,9 +1557,7 @@ struct Header<'a> {
 }
 
 impl<'a> Header<'a> {
-    fn new(tokens: Tokenizer<'a>,
-           array: bool,
-           require_newline_after_table: bool) -> Header<'a> {
+    fn new(tokens: Tokenizer<'a>, array: bool, require_newline_after_table: bool) -> Header<'a> {
         Header {
             first: true,
             array: array,
@@ -1513,13 +1612,13 @@ enum E<'a> {
 impl<'a> Value<'a> {
     fn same_type(&self, other: &Value<'a>) -> bool {
         match (&self.e, &other.e) {
-            (&E::String(..), &E::String(..)) |
-            (&E::Integer(..), &E::Integer(..)) |
-            (&E::Float(..), &E::Float(..)) |
-            (&E::Boolean(..), &E::Boolean(..)) |
-            (&E::Datetime(..), &E::Datetime(..)) |
-            (&E::Array(..), &E::Array(..)) |
-            (&E::InlineTable(..), &E::InlineTable(..)) => true,
+            (&E::String(..), &E::String(..))
+            | (&E::Integer(..), &E::Integer(..))
+            | (&E::Float(..), &E::Float(..))
+            | (&E::Boolean(..), &E::Boolean(..))
+            | (&E::Datetime(..), &E::Datetime(..))
+            | (&E::Array(..), &E::Array(..))
+            | (&E::InlineTable(..), &E::InlineTable(..)) => true,
             (&E::DottedTable(..), &E::DottedTable(..)) => true,
 
             _ => false,

--- a/src/de.rs
+++ b/src/de.rs
@@ -862,7 +862,7 @@ impl<'de> de::VariantAccess<'de> for TableEnumDeserializer<'de> {
                     })
                     // Fold all values into a `Vec`, or return the first error.
                     .fold(Ok(Vec::with_capacity(len)), |result, value_result| {
-                        result.and_then(|mut tuple_values| match value_result {
+                        result.and_then(move |mut tuple_values| match value_result {
                             Ok(value) => {
                                 tuple_values.push(value);
                                 Ok(tuple_values)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -32,8 +32,8 @@ use std::fmt::{self, Write};
 use std::marker;
 use std::rc::Rc;
 
-use serde::ser;
 use datetime;
+use serde::ser;
 
 /// Serialize the given data structure as a TOML byte vector.
 ///
@@ -41,7 +41,8 @@ use datetime;
 /// fail, if `T` contains a map with non-string keys, or if `T` attempts to
 /// serialize an unsupported datatype such as an enum, tuple, or tuple struct.
 pub fn to_vec<T: ?Sized>(value: &T) -> Result<Vec<u8>, Error>
-    where T: ser::Serialize,
+where
+    T: ser::Serialize,
 {
     to_string(value).map(|e| e.into_bytes())
 }
@@ -87,7 +88,8 @@ pub fn to_vec<T: ?Sized>(value: &T) -> Result<Vec<u8>, Error>
 /// }
 /// ```
 pub fn to_string<T: ?Sized>(value: &T) -> Result<String, Error>
-    where T: ser::Serialize,
+where
+    T: ser::Serialize,
 {
     let mut dst = String::with_capacity(128);
     value.serialize(&mut Serializer::new(&mut dst))?;
@@ -99,7 +101,8 @@ pub fn to_string<T: ?Sized>(value: &T) -> Result<String, Error>
 /// This is identical to `to_string` except the output string has a more
 /// "pretty" output. See `Serializer::pretty` for more details.
 pub fn to_string_pretty<T: ?Sized>(value: &T) -> Result<String, Error>
-    where T: ser::Serialize,
+where
+    T: ser::Serialize,
 {
     let mut dst = String::with_capacity(128);
     value.serialize(&mut Serializer::pretty(&mut dst))?;
@@ -177,9 +180,7 @@ struct StringSettings {
 
 impl StringSettings {
     fn pretty() -> StringSettings {
-        StringSettings {
-            literal: true,
-        }
+        StringSettings { literal: true }
     }
 }
 
@@ -239,7 +240,7 @@ pub enum SerializeTable<'a: 'b, 'b> {
         key: String,
         first: Cell<bool>,
         table_emitted: Cell<bool>,
-    }
+    },
 }
 
 impl<'a> Serializer<'a> {
@@ -333,13 +334,13 @@ impl<'a> Serializer<'a> {
     /// """
     /// ```
     pub fn pretty_string_literal(&mut self, value: bool) -> &mut Self {
-        let use_default = if let &mut Some(ref mut s) = &mut Rc::get_mut(&mut self.settings)
-                .unwrap().string {
-            s.literal = value;
-            false
-        } else {
-            true
-        };
+        let use_default =
+            if let &mut Some(ref mut s) = &mut Rc::get_mut(&mut self.settings).unwrap().string {
+                s.literal = value;
+                false
+            } else {
+                true
+            };
 
         if use_default {
             let mut string = StringSettings::pretty();
@@ -389,13 +390,13 @@ impl<'a> Serializer<'a> {
     ///
     /// See `Serializer::pretty_array` for more details.
     pub fn pretty_array_indent(&mut self, value: usize) -> &mut Self {
-        let use_default = if let &mut Some(ref mut a) = &mut Rc::get_mut(&mut self.settings)
-                .unwrap().array {
-            a.indent = value;
-            false
-        } else {
-            true
-        };
+        let use_default =
+            if let &mut Some(ref mut a) = &mut Rc::get_mut(&mut self.settings).unwrap().array {
+                a.indent = value;
+                false
+            } else {
+                true
+            };
 
         if use_default {
             let mut array = ArraySettings::pretty();
@@ -409,13 +410,13 @@ impl<'a> Serializer<'a> {
     ///
     /// See `Serializer::pretty_array` for more details.
     pub fn pretty_array_trailing_comma(&mut self, value: bool) -> &mut Self {
-        let use_default = if let &mut Some(ref mut a) = &mut Rc::get_mut(&mut self.settings)
-                .unwrap().array {
-            a.trailing_comma = value;
-            false
-        } else {
-            true
-        };
+        let use_default =
+            if let &mut Some(ref mut a) = &mut Rc::get_mut(&mut self.settings).unwrap().array {
+                a.trailing_comma = value;
+                false
+            } else {
+                true
+            };
 
         if use_default {
             let mut array = ArraySettings::pretty();
@@ -425,9 +426,7 @@ impl<'a> Serializer<'a> {
         self
     }
 
-    fn display<T: fmt::Display>(&mut self,
-                                t: T,
-                                type_: &'static str) -> Result<(), Error> {
+    fn display<T: fmt::Display>(&mut self, t: T, type_: &'static str) -> Result<(), Error> {
         self.emit_key(type_)?;
         drop(write!(self.dst, "{}", t));
         if let State::Table { .. } = self.state {
@@ -446,16 +445,26 @@ impl<'a> Serializer<'a> {
     fn _emit_key(&mut self, state: &State) -> Result<(), Error> {
         match *state {
             State::End => Ok(()),
-            State::Array { parent, first, type_, len } => {
+            State::Array {
+                parent,
+                first,
+                type_,
+                len,
+            } => {
                 assert!(type_.get().is_some());
                 if first.get() {
                     self._emit_key(parent)?;
                 }
                 self.emit_array(first, len)
             }
-            State::Table { parent, first, table_emitted, key } => {
+            State::Table {
+                parent,
+                first,
+                table_emitted,
+                key,
+            } => {
                 if table_emitted.get() {
-                    return Err(Error::ValueAfterTable)
+                    return Err(Error::ValueAfterTable);
                 }
                 if first.get() {
                     self.emit_table_header(parent)?;
@@ -476,7 +485,7 @@ impl<'a> Serializer<'a> {
                 } else {
                     self.dst.push_str(", ")
                 }
-            },
+            }
             (_, &Some(ref a)) => {
                 if first.get() {
                     self.dst.push_str("[\n")
@@ -486,7 +495,7 @@ impl<'a> Serializer<'a> {
                 for _ in 0..a.indent {
                     self.dst.push_str(" ");
                 }
-            },
+            }
         }
         Ok(())
     }
@@ -498,7 +507,7 @@ impl<'a> Serializer<'a> {
         };
         if let Some(prev) = prev.get() {
             if prev != type_ {
-                return Err(Error::ArrayMixedType)
+                return Err(Error::ArrayMixedType);
             }
         } else {
             prev.set(Some(type_));
@@ -507,14 +516,9 @@ impl<'a> Serializer<'a> {
     }
 
     fn escape_key(&mut self, key: &str) -> Result<(), Error> {
-        let ok = key.chars().all(|c| {
-            match c {
-                'a' ... 'z' |
-                'A' ... 'Z' |
-                '0' ... '9' |
-                '-' | '_' => true,
-                _ => false,
-            }
+        let ok = key.chars().all(|c| match c {
+            'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' => true,
+            _ => false,
         });
         if ok {
             drop(write!(self.dst, "{}", key));
@@ -570,7 +574,7 @@ impl<'a> Serializer<'a> {
                         found_singles = 0
                     }
                     match ch {
-                        '\t' => {},
+                        '\t' => {}
                         '\n' => ty = Type::NewlineTripple,
                         // note that the following are invalid: \b \f \r
                         c if c < '\u{1f}' => can_be_pretty = false, // Invalid control character
@@ -606,8 +610,9 @@ impl<'a> Serializer<'a> {
 
         let repr = if !is_key && self.settings.string.is_some() {
             match (&self.settings.string, do_pretty(value)) {
-                (&Some(StringSettings { literal: false, .. }), Repr::Literal(_, ty)) =>
-                    Repr::Std(ty),
+                (&Some(StringSettings { literal: false, .. }), Repr::Literal(_, ty)) => {
+                    Repr::Std(ty)
+                }
                 (_, r @ _) => r,
             }
         } else {
@@ -626,26 +631,23 @@ impl<'a> Serializer<'a> {
                     Type::OnelineSingle => self.dst.push('\''),
                     _ => self.dst.push_str("'''"),
                 }
-            },
+            }
             Repr::Std(ty) => {
                 match ty {
-                    Type::NewlineTripple =>  self.dst.push_str("\"\"\"\n"),
+                    Type::NewlineTripple => self.dst.push_str("\"\"\"\n"),
                     // note: OnelineTripple can happen if do_pretty wants to do
                     // '''it's one line'''
                     // but settings.string.literal == false
-                    Type::OnelineSingle |
-                        Type::OnelineTripple =>  self.dst.push('"'),
+                    Type::OnelineSingle | Type::OnelineTripple => self.dst.push('"'),
                 }
                 for ch in value.chars() {
                     match ch {
                         '\u{8}' => self.dst.push_str("\\b"),
                         '\u{9}' => self.dst.push_str("\\t"),
-                        '\u{a}' => {
-                            match ty {
-                                Type::NewlineTripple =>  self.dst.push('\n'),
-                                Type::OnelineSingle =>  self.dst.push_str("\\n"),
-                                _ => unreachable!(),
-                            }
+                        '\u{a}' => match ty {
+                            Type::NewlineTripple => self.dst.push('\n'),
+                            Type::OnelineSingle => self.dst.push_str("\\n"),
+                            _ => unreachable!(),
                         },
                         '\u{c}' => self.dst.push_str("\\f"),
                         '\u{d}' => self.dst.push_str("\\r"),
@@ -656,10 +658,10 @@ impl<'a> Serializer<'a> {
                     }
                 }
                 match ty {
-                    Type::NewlineTripple =>  self.dst.push_str("\"\"\""),
+                    Type::NewlineTripple => self.dst.push_str("\"\"\""),
                     Type::OnelineSingle | Type::OnelineTripple => self.dst.push('"'),
                 }
-            },
+            }
         }
         Ok(())
     }
@@ -684,7 +686,11 @@ impl<'a> Serializer<'a> {
             if !first.get() {
                 break;
             }
-            if let State::Array { parent: &State::Table {..}, ..} = *parent {
+            if let State::Array {
+                parent: &State::Table { .. },
+                ..
+            } = *parent
+            {
                 self.emit_table_header(parent)?;
                 break;
             }
@@ -697,7 +703,7 @@ impl<'a> Serializer<'a> {
                     // table in the document.
                     self.dst.push('\n');
                 }
-            },
+            }
             State::Array { parent, first, .. } => {
                 if !first.get() {
                     // Always newline if we are not the first item in the
@@ -709,7 +715,7 @@ impl<'a> Serializer<'a> {
                         self.dst.push('\n');
                     }
                 }
-            },
+            }
             _ => {}
         }
         self.dst.push_str("[");
@@ -728,9 +734,14 @@ impl<'a> Serializer<'a> {
         match *key {
             State::Array { parent, .. } => self.emit_key_part(parent),
             State::End => Ok(true),
-            State::Table { key, parent, table_emitted, .. } => {
+            State::Table {
+                key,
+                parent,
+                table_emitted,
+                ..
+            } => {
                 table_emitted.set(true);
-                let first  = self.emit_key_part(parent)?;
+                let first = self.emit_key_part(parent)?;
                 if !first {
                     self.dst.push_str(".");
                 }
@@ -841,7 +852,8 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<(), Self::Error>
-        where T: ser::Serialize
+    where
+        T: ser::Serialize,
     {
         value.serialize(self)
     }
@@ -850,40 +862,44 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
         Err(Error::UnsupportedType)
     }
 
-    fn serialize_unit_struct(self,
-                             _name: &'static str)
-                             -> Result<(), Self::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<(), Self::Error> {
         Err(Error::UnsupportedType)
     }
 
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              _variant_index: u32,
-                              variant: &'static str)
-                              -> Result<(), Self::Error> {
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<(), Self::Error> {
         self.serialize_str(variant)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T)
-                                           -> Result<(), Self::Error>
-        where T: ser::Serialize,
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
     {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(self,
-                                            _name: &'static str,
-                                            _variant_index: u32,
-                                            _variant: &'static str,
-                                            _value: &T)
-                                            -> Result<(), Self::Error>
-        where T: ser::Serialize,
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
     {
         Err(Error::UnsupportedType)
     }
 
-    fn serialize_seq(self, len: Option<usize>)
-                     -> Result<Self::SerializeSeq, Self::Error> {
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         self.array_type("array")?;
         Ok(SerializeSeq {
             ser: self,
@@ -893,27 +909,29 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
         })
     }
 
-    fn serialize_tuple(self, len: usize)
-                       -> Result<Self::SerializeTuple, Self::Error> {
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         self.serialize_seq(Some(len))
     }
 
-    fn serialize_tuple_struct(self, _name: &'static str, len: usize)
-                              -> Result<Self::SerializeTupleStruct, Self::Error> {
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         self.serialize_seq(Some(len))
     }
 
-    fn serialize_tuple_variant(self,
-                               _name: &'static str,
-                               _variant_index: u32,
-                               _variant: &'static str,
-                               len: usize)
-                               -> Result<Self::SerializeTupleVariant, Self::Error> {
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         self.serialize_seq(Some(len))
     }
 
-    fn serialize_map(self, _len: Option<usize>)
-                     -> Result<Self::SerializeMap, Self::Error> {
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         self.array_type("table")?;
         Ok(SerializeTable::Table {
             ser: self,
@@ -923,8 +941,11 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
         })
     }
 
-    fn serialize_struct(self, name: &'static str, _len: usize)
-                        -> Result<Self::SerializeStruct, Self::Error> {
+    fn serialize_struct(
+        self,
+        name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
         if name == datetime::NAME {
             self.array_type("datetime")?;
             Ok(SerializeTable::Datetime(self))
@@ -939,12 +960,13 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
         }
     }
 
-    fn serialize_struct_variant(self,
-                                _name: &'static str,
-                                _variant_index: u32,
-                                _variant: &'static str,
-                                _len: usize)
-                                -> Result<Self::SerializeStructVariant, Self::Error> {
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(Error::UnsupportedType)
     }
 }
@@ -954,7 +976,8 @@ impl<'a, 'b> ser::SerializeSeq for SerializeSeq<'a, 'b> {
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
-        where T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         value.serialize(&mut Serializer {
             dst: &mut *self.ser.dst,
@@ -973,19 +996,17 @@ impl<'a, 'b> ser::SerializeSeq for SerializeSeq<'a, 'b> {
     fn end(self) -> Result<(), Error> {
         match self.type_.get() {
             Some("table") => return Ok(()),
-            Some(_) => {
-                match (self.len, &self.ser.settings.array) {
-                    (Some(0...1), _) | (_, &None) => {
-                        self.ser.dst.push_str("]");
-                    },
-                    (_, &Some(ref a)) => {
-                        if a.trailing_comma {
-                            self.ser.dst.push_str(",");
-                        }
-                        self.ser.dst.push_str("\n]");
-                    },
+            Some(_) => match (self.len, &self.ser.settings.array) {
+                (Some(0...1), _) | (_, &None) => {
+                    self.ser.dst.push_str("]");
                 }
-            }
+                (_, &Some(ref a)) => {
+                    if a.trailing_comma {
+                        self.ser.dst.push_str(",");
+                    }
+                    self.ser.dst.push_str("\n]");
+                }
+            },
             None => {
                 assert!(self.first.get());
                 self.ser.emit_key("array")?;
@@ -1004,7 +1025,8 @@ impl<'a, 'b> ser::SerializeTuple for SerializeSeq<'a, 'b> {
     type Error = Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
-        where T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -1019,7 +1041,8 @@ impl<'a, 'b> ser::SerializeTupleVariant for SerializeSeq<'a, 'b> {
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
-        where T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -1034,7 +1057,8 @@ impl<'a, 'b> ser::SerializeTupleStruct for SerializeSeq<'a, 'b> {
     type Error = Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
-        where T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -1049,7 +1073,8 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
     type Error = Error;
 
     fn serialize_key<T: ?Sized>(&mut self, input: &T) -> Result<(), Error>
-        where T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         match *self {
             SerializeTable::Datetime(_) => panic!(), // shouldn't be possible
@@ -1062,7 +1087,8 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
     }
 
     fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Error>
-        where T: ser::Serialize,
+    where
+        T: ser::Serialize,
     {
         match *self {
             SerializeTable::Datetime(_) => panic!(), // shouldn't be possible
@@ -1085,7 +1111,7 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
                 });
                 match res {
                     Ok(()) => first.set(false),
-                    Err(Error::UnsupportedNone) => {},
+                    Err(Error::UnsupportedNone) => {}
                     Err(e) => return Err(e),
                 }
             }
@@ -1096,7 +1122,7 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
     fn end(self) -> Result<(), Error> {
         match self {
             SerializeTable::Datetime(_) => panic!(), // shouldn't be possible
-            SerializeTable::Table { ser, first, ..  } => {
+            SerializeTable::Table { ser, first, .. } => {
                 if first.get() {
                     let state = ser.state.clone();
                     ser.emit_table_header(&state)?;
@@ -1111,16 +1137,16 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T)
-                                  -> Result<(), Error>
-        where T: ser::Serialize,
+    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Error>
+    where
+        T: ser::Serialize,
     {
         match *self {
             SerializeTable::Datetime(ref mut ser) => {
                 if key == datetime::FIELD {
                     value.serialize(DateStrEmitter(&mut *ser))?;
                 } else {
-                    return Err(Error::DateInvalid)
+                    return Err(Error::DateInvalid);
                 }
             }
             SerializeTable::Table {
@@ -1141,7 +1167,7 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
                 });
                 match res {
                     Ok(()) => first.set(false),
-                    Err(Error::UnsupportedNone) => {},
+                    Err(Error::UnsupportedNone) => {}
                     Err(e) => return Err(e),
                 }
             }
@@ -1151,8 +1177,8 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
 
     fn end(self) -> Result<(), Error> {
         match self {
-            SerializeTable::Datetime(_) => {},
-            SerializeTable::Table { ser, first, ..  } => {
+            SerializeTable::Datetime(_) => {}
+            SerializeTable::Table { ser, first, .. } => {
                 if first.get() {
                     let state = ser.state.clone();
                     ser.emit_table_header(&state)?;
@@ -1238,7 +1264,8 @@ impl<'a, 'b> ser::Serializer for DateStrEmitter<'a, 'b> {
     }
 
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<(), Self::Error>
-        where T: ser::Serialize
+    where
+        T: ser::Serialize,
     {
         Err(Error::KeyNotString)
     }
@@ -1247,78 +1274,88 @@ impl<'a, 'b> ser::Serializer for DateStrEmitter<'a, 'b> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_unit_struct(self,
-                             _name: &'static str)
-                             -> Result<(), Self::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<(), Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              _variant_index: u32,
-                              _variant: &'static str)
-                              -> Result<(), Self::Error> {
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<(), Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T)
-                                           -> Result<(), Self::Error>
-        where T: ser::Serialize,
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
     {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(self,
-                                            _name: &'static str,
-                                            _variant_index: u32,
-                                            _variant: &'static str,
-                                            _value: &T)
-                                            -> Result<(), Self::Error>
-        where T: ser::Serialize,
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
     {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_seq(self, _len: Option<usize>)
-                     -> Result<Self::SerializeSeq, Self::Error> {
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_tuple(self, _len: usize)
-                       -> Result<Self::SerializeTuple, Self::Error> {
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_tuple_struct(self, _name: &'static str, _len: usize)
-                              -> Result<Self::SerializeTupleStruct, Self::Error> {
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_tuple_variant(self,
-                               _name: &'static str,
-                               _variant_index: u32,
-                               _variant: &'static str,
-                               _len: usize)
-                               -> Result<Self::SerializeTupleVariant, Self::Error> {
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_map(self, _len: Option<usize>)
-                     -> Result<Self::SerializeMap, Self::Error> {
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_struct(self, _name: &'static str, _len: usize)
-                        -> Result<Self::SerializeStruct, Self::Error> {
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
         Err(Error::DateInvalid)
     }
 
-    fn serialize_struct_variant(self,
-                                _name: &'static str,
-                                _variant_index: u32,
-                                _variant: &'static str,
-                                _len: usize)
-                                -> Result<Self::SerializeStructVariant, Self::Error> {
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(Error::DateInvalid)
     }
 }
@@ -1397,7 +1434,8 @@ impl ser::Serializer for StringExtractor {
     }
 
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<String, Self::Error>
-        where T: ser::Serialize
+    where
+        T: ser::Serialize,
     {
         Err(Error::KeyNotString)
     }
@@ -1406,78 +1444,88 @@ impl ser::Serializer for StringExtractor {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_unit_struct(self,
-                             _name: &'static str)
-                             -> Result<String, Self::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<String, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_unit_variant(self,
-                              _name: &'static str,
-                              _variant_index: u32,
-                              _variant: &'static str)
-                              -> Result<String, Self::Error> {
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<String, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T)
-                                           -> Result<String, Self::Error>
-        where T: ser::Serialize,
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<String, Self::Error>
+    where
+        T: ser::Serialize,
     {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(self,
-                                            _name: &'static str,
-                                            _variant_index: u32,
-                                            _variant: &'static str,
-                                            _value: &T)
-                                            -> Result<String, Self::Error>
-        where T: ser::Serialize,
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<String, Self::Error>
+    where
+        T: ser::Serialize,
     {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_seq(self, _len: Option<usize>)
-                     -> Result<Self::SerializeSeq, Self::Error> {
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_tuple(self, _len: usize)
-                       -> Result<Self::SerializeTuple, Self::Error> {
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_tuple_struct(self, _name: &'static str, _len: usize)
-                              -> Result<Self::SerializeTupleStruct, Self::Error> {
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_tuple_variant(self,
-                               _name: &'static str,
-                               _variant_index: u32,
-                               _variant: &'static str,
-                               _len: usize)
-                               -> Result<Self::SerializeTupleVariant, Self::Error> {
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_map(self, _len: Option<usize>)
-                     -> Result<Self::SerializeMap, Self::Error> {
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_struct(self, _name: &'static str, _len: usize)
-                        -> Result<Self::SerializeStruct, Self::Error> {
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
         Err(Error::KeyNotString)
     }
 
-    fn serialize_struct_variant(self,
-                                _name: &'static str,
-                                _variant_index: u32,
-                                _variant: &'static str,
-                                _len: usize)
-                                -> Result<Self::SerializeStructVariant, Self::Error> {
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(Error::KeyNotString)
     }
 }
@@ -1549,12 +1597,12 @@ enum Category {
 /// # type Dependency = String;
 /// # fn main() {}
 /// ```
-pub fn tables_last<'a, I, K, V, S>(data: &'a I, serializer: S)
-                                   -> Result<S::Ok, S::Error>
-    where &'a I: IntoIterator<Item = (K, V)>,
-          K: ser::Serialize,
-          V: ser::Serialize,
-          S: ser::Serializer
+pub fn tables_last<'a, I, K, V, S>(data: &'a I, serializer: S) -> Result<S::Ok, S::Error>
+where
+    &'a I: IntoIterator<Item = (K, V)>,
+    K: ser::Serialize,
+    V: ser::Serialize,
+    S: ser::Serializer,
 {
     use serde::ser::SerializeMap;
 
@@ -1668,15 +1716,30 @@ impl<E: ser::Error> ser::Serializer for Categorize<E> {
         Err(ser::Error::custom("unsupported"))
     }
 
-    fn serialize_unit_variant(self, _: &'static str, _: u32, _: &'static str) -> Result<Self::Ok, Self::Error> {
+    fn serialize_unit_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
         Err(ser::Error::custom("unsupported"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(self, _: &'static str, v: &T) -> Result<Self::Ok, Self::Error> {
+    fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(
+        self,
+        _: &'static str,
+        v: &T,
+    ) -> Result<Self::Ok, Self::Error> {
         v.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(self, _: &'static str, _: u32, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error> {
+    fn serialize_newtype_variant<T: ?Sized + ser::Serialize>(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: &T,
+    ) -> Result<Self::Ok, Self::Error> {
         Err(ser::Error::custom("unsupported"))
     }
 
@@ -1688,11 +1751,21 @@ impl<E: ser::Error> ser::Serializer for Categorize<E> {
         Ok(self)
     }
 
-    fn serialize_tuple_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeTupleStruct, Self::Error> {
+    fn serialize_tuple_struct(
+        self,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         Ok(self)
     }
 
-    fn serialize_tuple_variant(self, _: &'static str, _: u32, _: &'static str, _: usize) -> Result<Self::SerializeTupleVariant, Self::Error> {
+    fn serialize_tuple_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
         Ok(self)
     }
 
@@ -1704,7 +1777,13 @@ impl<E: ser::Error> ser::Serializer for Categorize<E> {
         Ok(self)
     }
 
-    fn serialize_struct_variant(self, _: &'static str, _: u32, _: &'static str, _: usize) -> Result<Self::SerializeStructVariant, Self::Error> {
+    fn serialize_struct_variant(
+        self,
+        _: &'static str,
+        _: u32,
+        _: &'static str,
+        _: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(ser::Error::custom("unsupported"))
     }
 }
@@ -1713,8 +1792,7 @@ impl<E: ser::Error> ser::SerializeSeq for Categorize<E> {
     type Ok = Category;
     type Error = E;
 
-    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, _: &T)
-                                                     -> Result<(), Self::Error> {
+    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, _: &T) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -1727,8 +1805,7 @@ impl<E: ser::Error> ser::SerializeTuple for Categorize<E> {
     type Ok = Category;
     type Error = E;
 
-    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, _: &T)
-                                                     -> Result<(), Self::Error> {
+    fn serialize_element<T: ?Sized + ser::Serialize>(&mut self, _: &T) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -1741,8 +1818,7 @@ impl<E: ser::Error> ser::SerializeTupleVariant for Categorize<E> {
     type Ok = Category;
     type Error = E;
 
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, _: &T)
-                                                   -> Result<(), Self::Error> {
+    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, _: &T) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -1755,8 +1831,7 @@ impl<E: ser::Error> ser::SerializeTupleStruct for Categorize<E> {
     type Ok = Category;
     type Error = E;
 
-    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, _: &T)
-                                                   -> Result<(), Self::Error> {
+    fn serialize_field<T: ?Sized + ser::Serialize>(&mut self, _: &T) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -1769,13 +1844,11 @@ impl<E: ser::Error> ser::SerializeMap for Categorize<E> {
     type Ok = Category;
     type Error = E;
 
-    fn serialize_key<T: ?Sized + ser::Serialize>(&mut self, _: &T)
-                                                 -> Result<(), Self::Error> {
+    fn serialize_key<T: ?Sized + ser::Serialize>(&mut self, _: &T) -> Result<(), Self::Error> {
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized + ser::Serialize>(&mut self, _: &T)
-                                                   -> Result<(), Self::Error> {
+    fn serialize_value<T: ?Sized + ser::Serialize>(&mut self, _: &T) -> Result<(), Self::Error> {
         Ok(())
     }
 
@@ -1788,10 +1861,9 @@ impl<E: ser::Error> ser::SerializeStruct for Categorize<E> {
     type Ok = Category;
     type Error = E;
 
-    fn serialize_field<T: ?Sized>(&mut self,
-                                  _: &'static str,
-                                  _: &T) -> Result<(), Self::Error>
-        where T: ser::Serialize,
+    fn serialize_field<T: ?Sized>(&mut self, _: &'static str, _: &T) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
     {
         Ok(())
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -928,15 +928,23 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
 
     fn serialize_newtype_variant<T: ?Sized>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
-        _value: &T,
+        variant: &'static str,
+        value: &T,
     ) -> Result<(), Self::Error>
     where
         T: ser::Serialize,
     {
-        Err(Error::UnsupportedType)
+        self.dst.push_str("{ ");
+        self.dst.push_str(variant);
+        self.dst.push_str(" = ");
+
+        self.serialize_newtype_struct(name, value)?;
+
+        self.dst.push_str(" }");
+
+        Ok(())
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -912,7 +912,17 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<(), Self::Error> {
-        self.serialize_str(variant)
+        match self.state {
+            State::Array { .. } => {
+                self.array_type("inline_table")?;
+
+                self.dst.push_str("{ ");
+                self.emit_str(variant, true)?;
+                self.dst.push_str(" = {} }");
+            }
+            _ => self.serialize_str(variant)?,
+        }
+        Ok(())
     }
 
     fn serialize_newtype_struct<T: ?Sized>(

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -1,0 +1,153 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
+
+#[derive(Debug, Deserialize, PartialEq)]
+enum TheEnum {
+    Plain,
+    Tuple(i64, bool),
+    NewType(String),
+    Struct { value: i64 },
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Val {
+    val: TheEnum,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Multi {
+    enums: Vec<TheEnum>,
+}
+
+mod enum_unit {
+    use super::*;
+
+    #[test]
+    fn from_str() {
+        assert_eq!(TheEnum::Plain, toml::from_str("\"Plain\"").unwrap());
+    }
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(TheEnum::Plain, toml::from_str("{ Plain = {} }").unwrap());
+        assert_eq!(
+            Val {
+                val: TheEnum::Plain
+            },
+            toml::from_str("val = { Plain = {} }").unwrap()
+        );
+    }
+
+    #[test]
+    fn from_dotted_table() {
+        assert_eq!(TheEnum::Plain, toml::from_str("[Plain]\n").unwrap());
+    }
+}
+
+mod enum_tuple {
+    use super::*;
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(
+            TheEnum::Tuple(-123, true),
+            toml::from_str("{ Tuple = { 0 = -123, 1 = true } }").unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::Tuple(-123, true)
+            },
+            toml::from_str("val = { Tuple = { 0 = -123, 1 = true } }").unwrap()
+        );
+    }
+
+    #[test]
+    fn from_dotted_table() {
+        assert_eq!(
+            TheEnum::Tuple(-123, true),
+            toml::from_str(
+                r#"[Tuple]
+                0 = -123
+                1 = true
+                "#
+            )
+            .unwrap()
+        );
+    }
+}
+
+mod enum_newtype {
+    use super::*;
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(
+            TheEnum::NewType("value".to_string()),
+            toml::from_str(r#"{ NewType = "value" }"#).unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::NewType("value".to_string()),
+            },
+            toml::from_str(r#"val = { NewType = "value" }"#).unwrap()
+        );
+    }
+}
+
+mod enum_struct {
+    use super::*;
+
+    #[test]
+    fn from_inline_table() {
+        assert_eq!(
+            TheEnum::Struct { value: -123 },
+            toml::from_str("{ Struct = { value = -123 } }").unwrap()
+        );
+        assert_eq!(
+            Val {
+                val: TheEnum::Struct { value: -123 }
+            },
+            toml::from_str("val = { Struct = { value = -123 } }").unwrap()
+        );
+    }
+
+    #[test]
+    fn from_dotted_table() {
+        assert_eq!(
+            TheEnum::Struct { value: -123 },
+            toml::from_str(
+                r#"[Struct]
+                value = -123
+                "#
+            )
+            .unwrap()
+        );
+    }
+}
+
+mod enum_array {
+    use super::*;
+
+    #[test]
+    fn from_inline_tables() {
+        let toml_str = r#"
+            enums = [
+                { Plain = {} },
+                { Tuple = { 0 = -123, 1 = true } },
+                { NewType = "value" },
+                { Struct = { value = -123 } }
+            ]"#;
+        assert_eq!(
+            Multi {
+                enums: vec![
+                    TheEnum::Plain,
+                    TheEnum::Tuple(-123, true),
+                    TheEnum::NewType("value".to_string()),
+                    TheEnum::Struct { value: -123 },
+                ]
+            },
+            toml::from_str(toml_str).unwrap()
+        );
+    }
+}

--- a/tests/enum_external_serialize.rs
+++ b/tests/enum_external_serialize.rs
@@ -32,3 +32,11 @@ fn enum_tuple_serializes_to_inline_table() {
         toml::to_string(&TheEnum::Tuple(-123, true)).unwrap()
     );
 }
+
+#[test]
+fn enum_newtype_serializes_to_inline_table() {
+    assert_eq!(
+        r#"{ NewType = "value" }"#,
+        toml::to_string(&TheEnum::NewType("value".to_string())).unwrap()
+    );
+}

--- a/tests/enum_external_serialize.rs
+++ b/tests/enum_external_serialize.rs
@@ -40,3 +40,11 @@ fn enum_newtype_serializes_to_inline_table() {
         toml::to_string(&TheEnum::NewType("value".to_string())).unwrap()
     );
 }
+
+#[test]
+fn enum_struct_serializes_to_inline_table() {
+    assert_eq!(
+        r#"{ Struct = { value = -123 } }"#,
+        toml::to_string(&TheEnum::Struct { value: -123 }).unwrap()
+    );
+}

--- a/tests/enum_external_serialize.rs
+++ b/tests/enum_external_serialize.rs
@@ -48,3 +48,27 @@ fn enum_struct_serializes_to_inline_table() {
         toml::to_string(&TheEnum::Struct { value: -123 }).unwrap()
     );
 }
+
+#[test]
+fn array_of_variants_serializes_to_inline_tables() {
+    let toml_str = r#"
+        enums = [
+            { Plain = {} },
+            { Tuple = { 0 = -123, 1 = true } },
+            { NewType = "value" },
+            { Struct = { value = -123 } }
+        ]"#;
+
+    assert_eq!(
+        toml_str,
+        toml::to_string(&Multi {
+            enums: vec![
+                TheEnum::Plain,
+                TheEnum::Tuple(-123, true),
+                TheEnum::NewType("value".to_string()),
+                TheEnum::Struct { value: -123 },
+            ]
+        })
+        .unwrap(),
+    );
+}

--- a/tests/enum_external_serialize.rs
+++ b/tests/enum_external_serialize.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate serde_derive;
+extern crate toml;
+
+#[derive(Debug, Serialize, PartialEq)]
+enum TheEnum {
+    Plain,
+    Tuple(i64, bool),
+    NewType(String),
+    Struct { value: i64 },
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Val {
+    val: TheEnum,
+}
+
+#[derive(Debug, Serialize, PartialEq)]
+struct Multi {
+    enums: Vec<TheEnum>,
+}
+
+#[test]
+fn enum_unit_serializes_to_string_when_standalone() {
+    assert_eq!(r#""Plain""#, toml::to_string(&TheEnum::Plain).unwrap());
+}
+
+#[test]
+fn enum_tuple_serializes_to_inline_table() {
+    assert_eq!(
+        r#"{ Tuple = { 0 = -123, 1 = true } }"#,
+        toml::to_string(&TheEnum::Tuple(-123, true)).unwrap()
+    );
+}


### PR DESCRIPTION
*See https://github.com/alexcrichton/toml-rs/pull/264 for deserialization*

Serialization half of #225. I haven't managed to get it functioning, let alone clean. Learnings so far:

* `src/ser.rs` contains the `Serializer` which stores some information to track "what type is used in the last output array"
* When serializing hierarchical data (e.g. array containing an inline table), it should instantiate a separate `Serializer` (or store the context in some sort of stack)
* It doesn't do that, so when serializing part of the inline table's data into a toml string, and it checks "is my last array type also a string", it fails because it stores "inline_table" as the last type in the array.

Fixing this would probably require restructuring how the serialization context is stored. I'm taking a break from working on this so if anyone would like to continue it, please do!

---

On the branch, there's an `tests/enum_external_serialize.rs` file which is meant to show how it will be used. Also, probably want to implement pretty print and non-pretty print properly
