### PR TITLE
Support tuple Serde types for `Value`

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -675,9 +675,9 @@ impl ser::Serializer for Serializer {
     type Error = ::ser::Error;
 
     type SerializeSeq = SerializeVec;
-    type SerializeTuple = ser::Impossible<Value, ::ser::Error>;
-    type SerializeTupleStruct = ser::Impossible<Value, ::ser::Error>;
-    type SerializeTupleVariant = ser::Impossible<Value, ::ser::Error>;
+    type SerializeTuple = SerializeVec;
+    type SerializeTupleStruct = SerializeVec;
+    type SerializeTupleVariant = SerializeVec;
     type SerializeMap = SerializeMap;
     type SerializeStruct = SerializeMap;
     type SerializeStructVariant = ser::Impossible<Value, ::ser::Error>;
@@ -800,23 +800,23 @@ impl ser::Serializer for Serializer {
         })
     }
 
-    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, ::ser::Error> {
-        Err(::ser::Error::UnsupportedType)
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, ::ser::Error> {
+        self.serialize_seq(Some(len))
     }
 
-    fn serialize_tuple_struct(self, _name: &'static str, _len: usize)
+    fn serialize_tuple_struct(self, _name: &'static str, len: usize)
                               -> Result<Self::SerializeTupleStruct, ::ser::Error> {
-        Err(::ser::Error::UnsupportedType)
+        self.serialize_seq(Some(len))
     }
 
     fn serialize_tuple_variant(self,
                                _name: &'static str,
                                _variant_index: u32,
                                _variant: &'static str,
-                               _len: usize)
+                               len: usize)
                                -> Result<Self::SerializeTupleVariant, ::ser::Error>
     {
-        Err(::ser::Error::UnsupportedType)
+        self.serialize_seq(Some(len))
     }
 
     fn serialize_map(self, _len: Option<usize>)
@@ -866,6 +866,51 @@ impl ser::SerializeSeq for SerializeVec {
 
     fn end(self) -> Result<Value, ::ser::Error> {
         Ok(Value::Array(self.vec))
+    }
+}
+
+impl ser::SerializeTuple for SerializeVec {
+    type Ok = Value;
+    type Error = ::ser::Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), ::ser::Error>
+        where T: ser::Serialize
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value, ::ser::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeTupleStruct for SerializeVec {
+    type Ok = Value;
+    type Error = ::ser::Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), ::ser::Error>
+        where T: ser::Serialize
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value, ::ser::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeTupleVariant for SerializeVec {
+    type Ok = Value;
+    type Error = ::ser::Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), ::ser::Error>
+        where T: ser::Serialize
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value, ::ser::Error> {
+        ser::SerializeSeq::end(self)
     }
 }
 

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -580,15 +580,63 @@ fn table_structs_empty() {
 
 #[test]
 fn fixed_size_array() {
-    #[derive(Serialize, PartialEq, Eq, Deserialize, Debug)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Entity {
         pos: [i32; 2]
     }
-    let text = "pos = [1, 2]\n";
-    let value: Entity = toml::from_str(text).unwrap();
-    let expected = Entity { pos: [1, 2] };
-    assert_eq!(value, expected);
-    assert_eq!(toml::to_string(&value).unwrap(), text);
+
+    equivalent! {
+        Entity { pos: [1, 2] },
+        Table(map! {
+            pos: Array(vec![
+                Integer(1),
+                Integer(2),
+            ])
+        }),
+    }
+}
+
+#[test]
+fn homogeneous_tuple() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Collection {
+        elems: (i64, i64, i64),
+    }
+
+    equivalent! {
+        Collection { elems: (0, 1, 2) },
+        Table(map! {
+            elems: Array(vec![
+                Integer(0),
+                Integer(1),
+                Integer(2),
+            ])
+        }),
+    }
+}
+
+#[test]
+fn homogeneous_tuple_struct() {
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    struct Object(Vec<String>, Vec<String>, Vec<String>);
+
+    equivalent! {
+        map! {
+            obj: Object(vec!["foo".to_string()], vec![], vec!["bar".to_string(), "baz".to_string()])
+        },
+        Table(map! {
+            obj: Array(vec![
+                Array(vec![
+                    Value::String("foo".to_string()),
+                ]),
+                Array(vec![]),
+                Array(vec![
+                    Value::String("bar".to_string()),
+                    Value::String("baz".to_string()),
+                ]),
+            ])
+        }),
+    }
 }
 
 #[test]


### PR DESCRIPTION
With https://github.com/alexcrichton/toml-rs/pull/245 already allowing tuples, tuple structs and tuple variants for string serialization, there is no reason `toml::Value` should not have the same capability as well!