### PR TITLE
Fix disallowing duplicate table headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ facilitate deserializing and serializing Rust structures.
 """
 categories = ["config", "encoding", "parser-implementations"]
 
+[workspace]
+members = ['test-suite']
+
 [badges]
 travis-ci = { repository = "alexcrichton/toml-rs" }
 

--- a/test-suite/tests/backcompat.rs
+++ b/test-suite/tests/backcompat.rs
@@ -4,7 +4,7 @@ extern crate serde;
 use serde::de::Deserialize;
 
 #[test]
-fn main() {
+fn newlines_after_tables() {
     let s = "
         [a] foo = 1
         [[b]] foo = 1
@@ -16,4 +16,26 @@ fn main() {
     let value = toml::Value::deserialize(&mut d).unwrap();
     assert_eq!(value["a"]["foo"].as_integer(), Some(1));
     assert_eq!(value["b"][0]["foo"].as_integer(), Some(1));
+}
+
+#[test]
+fn allow_duplicate_after_longer() {
+    let s = "
+        [dependencies.openssl-sys]
+        version = 1
+
+        [dependencies]
+        libc = 1
+
+        [dependencies]
+        bitflags = 1
+    ";
+    assert!(s.parse::<toml::Value>().is_err());
+
+    let mut d = toml::de::Deserializer::new(s);
+    d.set_allow_duplicate_after_longer_table(true);
+    let value = toml::Value::deserialize(&mut d).unwrap();
+    assert_eq!(value["dependencies"]["openssl-sys"]["version"].as_integer(), Some(1));
+    assert_eq!(value["dependencies"]["libc"].as_integer(), Some(1));
+    assert_eq!(value["dependencies"]["bitflags"].as_integer(), Some(1));
 }

--- a/test-suite/tests/invalid.rs
+++ b/test-suite/tests/invalid.rs
@@ -96,3 +96,5 @@ test!(text_before_array_separator,
       include_str!("invalid/text-before-array-separator.toml"));
 test!(text_in_array,
       include_str!("invalid/text-in-array.toml"));
+test!(duplicate_table,
+      include_str!("invalid/duplicate-table.toml"));

--- a/test-suite/tests/invalid/duplicate-table.toml
+++ b/test-suite/tests/invalid/duplicate-table.toml
@@ -1,0 +1,8 @@
+[dependencies.openssl-sys]
+version = "0.5.2"
+
+[dependencies]
+libc = "0.1"
+
+[dependencies]
+bitflags = "0.1.1"


### PR DESCRIPTION
This commit fixes #279 where a case of duplicate table headers slipped
through the cracks. This also adds an option to disable this new
validation to allow Cargo to preserve backwards compatibility.