### PR TITLE
Fix parsing of repeated delimiters inside multi-line strings

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -336,11 +336,14 @@ impl<'a> Tokenizer<'a> {
                 }
                 Some((i, ch)) if ch == delim => {
                     if multiline {
-                        for _ in 0..2 {
-                            if !self.eatc(delim) {
-                                val.push(delim);
-                                continue 'outer;
-                            }
+                        if !self.eatc(delim) {
+                            val.push(delim);
+                            continue 'outer;
+                        }
+                        if !self.eatc(delim) {
+                            val.push(delim);
+                            val.push(delim);
+                            continue 'outer;
                         }
                     }
                     return Ok(String {
@@ -630,6 +633,7 @@ mod tests {
         t(r#""\"a""#, "\"a", false);
         t("\"\"\"\na\"\"\"", "a", true);
         t("\"\"\"\n\"\"\"", "", true);
+        t(r#""""a\"""b""""#, "a\"\"\"b", true);
         err(r#""\a"#, Error::InvalidEscape(2, 'a'));
         err("\"\\\n", Error::InvalidEscape(2, '\n'));
         err("\"\\\r\n", Error::InvalidEscape(2, '\n'));


### PR DESCRIPTION
The previous implementation of `read_string`, when looking for
delimiters ending the multi-line string and failing to find exactly
three in succession, always put a single delimiter back. This is
incorrect when exactly two delimiters are present.

Put back the correct number of delimiters depending on how many have
been already consumed from input.

The issue could be triggered only with `Owned` representation of
`MaybeString`, since otherwise `push` operation is no-op.