### PR TITLE
Remove rustc version checking.

### DIFF
--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -2,11 +2,7 @@
 name = "toml_test_suite"
 version = "0.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-build = "build.rs"
 publish = false
-
-[build-dependencies]
-rustc_version = "0.2"
 
 [dev-dependencies]
 toml = { path = ".." }

--- a/test-suite/build.rs
+++ b/test-suite/build.rs
@@ -1,9 +1,0 @@
-extern crate rustc_version;
-use rustc_version::{version, Version};
-
-fn main() {
-    if version().unwrap() >= Version::parse("1.20.0").unwrap() {
-        println!(r#"cargo:rustc-cfg=feature="test-quoted-keys-in-macro""#);
-        println!(r#"cargo:rustc-cfg=feature="test-nan-sign""#);
-    }
-}

--- a/test-suite/tests/float.rs
+++ b/test-suite/tests/float.rs
@@ -72,7 +72,6 @@ sf8 = -0.0
 }
 
 #[test]
-#[cfg(feature = "test-nan-sign")]
 fn float_inf() {
     float_inf_tests!(f32);
     float_inf_tests!(f64);

--- a/test-suite/tests/macros.rs
+++ b/test-suite/tests/macros.rs
@@ -279,7 +279,6 @@ fn test_datetime() {
 
 // This test requires rustc >= 1.20.
 #[test]
-#[cfg(feature = "test-quoted-keys-in-macro")]
 fn test_quoted_key() {
     let actual = toml! {
         "quoted" = true


### PR DESCRIPTION
This is no longer necessary, as <1.20 is no longer supported.