### PR TITLE
Bump Serde dependency to 1.0.97

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = ['test-suite']
 travis-ci = { repository = "alexcrichton/toml-rs" }
 
 [dependencies]
-serde = "1.0"
+serde = "1.0.97"
 linked-hash-map = { version = "0.5", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
toml-rs depends on some Serde types not present in Serde 1.0.0 (e.g
BorrowedStrDeserializer). By explicitly depending on a newever version,
we ensure compatibility with any crates using '-Z minimal-versions'

Note that we could probably depend on an older version of Serde, but I
didn't see much point in finding the exact minimum patch release that's
compatible with toml-rs