### PR TITLE
Allow conversion from de::Error to std::io::error

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1769,6 +1769,13 @@ impl Error {
     #[doc(hidden)]
     pub fn add_key_context(&mut self, key: &str) {
         self.inner.key.insert(0, key.to_string());
+    }    
+
+}
+
+impl std::convert::From<Error> for std::io::Error {
+    fn from(e: Error) -> Self {
+        return std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
     }
 }
 


### PR DESCRIPTION
Hi there! 

Use case is to allow something like this:

```
pub fn load(file_path: &str) -> Result<TaskToml, std::io::Error> {
    let t: TaskToml = toml::from_str(
        &fs::read_to_string(file_path)?
    )?;

    Ok(t)
}
```