### PR TITLE
Include Spanned in the docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,5 +166,4 @@ mod tokens;
 pub mod macros;
 
 mod spanned;
-#[doc(no_inline)]
 pub use crate::spanned::Spanned;

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,23 +1,3 @@
-//! ```
-//! use serde_derive::Deserialize;
-//! use toml::Spanned;
-//!
-//! #[derive(Deserialize)]
-//! struct Value {
-//!     s: Spanned<String>,
-//! }
-//!
-//! fn main() {
-//!     let t = "s = \"value\"\n";
-//!
-//!     let u: Value = toml::from_str(t).unwrap();
-//!
-//!     assert_eq!(u.s.start(), 4);
-//!     assert_eq!(u.s.end(), 11);
-//!     assert_eq!(u.s.get_ref(), "value");
-//!     assert_eq!(u.s.into_inner(), String::from("value"));
-//! }
-//! ```
 
 use serde::{de, ser};
 use std::fmt;
@@ -32,6 +12,27 @@ pub const END: &'static str = "$__toml_private_end";
 pub const VALUE: &'static str = "$__toml_private_value";
 
 /// A spanned value, indicating the range at which it is defined in the source.
+///
+/// ```
+/// use serde_derive::Deserialize;
+/// use toml::Spanned;
+///
+/// #[derive(Deserialize)]
+/// struct Value {
+///     s: Spanned<String>,
+/// }
+///
+/// fn main() {
+///     let t = "s = \"value\"\n";
+///
+///     let u: Value = toml::from_str(t).unwrap();
+///
+///     assert_eq!(u.s.start(), 4);
+///     assert_eq!(u.s.end(), 11);
+///     assert_eq!(u.s.get_ref(), "value");
+///     assert_eq!(u.s.into_inner(), String::from("value"));
+/// }
+/// ```
 #[derive(Debug)]
 pub struct Spanned<T> {
     /// The start range.


### PR DESCRIPTION
The `Spanned` struct was originally included in the docs as a re-export, but rustdoc doesn't render re-exports if the module from which it's exported isn't documented.

Since `Spanned` is the only public item inside the `spanned` module this commit shows the struct as a normal item in the index, and moves the example from the module docs to the struct docs.

Fixes https://github.com/alexcrichton/toml-rs/issues/309