### PR TITLE
Simplified Logic when comparing discriminants

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::error;
 use std::f64;
 use std::fmt;
+use std::mem::discriminant;
 use std::str;
 use std::vec;
 
@@ -2057,17 +2058,6 @@ impl<'a> E<'a> {
 
 impl<'a> Value<'a> {
     fn same_type(&self, other: &Value<'a>) -> bool {
-        match (&self.e, &other.e) {
-            (&E::String(..), &E::String(..))
-            | (&E::Integer(..), &E::Integer(..))
-            | (&E::Float(..), &E::Float(..))
-            | (&E::Boolean(..), &E::Boolean(..))
-            | (&E::Datetime(..), &E::Datetime(..))
-            | (&E::Array(..), &E::Array(..))
-            | (&E::InlineTable(..), &E::InlineTable(..)) => true,
-            (&E::DottedTable(..), &E::DottedTable(..)) => true,
-
-            _ => false,
-        }
+        discriminant(&self.e) == discriminant(&other.e)
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::hash::Hash;
+use std::mem::discriminant;
 use std::ops;
 use std::str::FromStr;
 use std::vec;
@@ -212,17 +213,7 @@ impl Value {
 
     /// Tests whether this and another value have the same type.
     pub fn same_type(&self, other: &Value) -> bool {
-        match (self, other) {
-            (&Value::String(..), &Value::String(..))
-            | (&Value::Integer(..), &Value::Integer(..))
-            | (&Value::Float(..), &Value::Float(..))
-            | (&Value::Boolean(..), &Value::Boolean(..))
-            | (&Value::Datetime(..), &Value::Datetime(..))
-            | (&Value::Array(..), &Value::Array(..))
-            | (&Value::Table(..), &Value::Table(..)) => true,
-
-            _ => false,
-        }
+        discriminant(self) == discriminant(other)
     }
 
     /// Returns a human-readable representation of the type of this value.


### PR DESCRIPTION
Removed matches that were used to compare Enum variants for equality in
favor of using `discriminant` from [1.21.0](https://doc.rust-lang.org/std/mem/fn.discriminant.html)
that's cleaner and more idiomatic.