### PR TITLE
Fix error line/column when using CRLF line endings.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1775,7 +1775,10 @@ impl<'a> Deserializer<'a> {
     /// All indexes are 0-based.
     fn to_linecol(&self, offset: usize) -> (usize, usize) {
         let mut cur = 0;
-        for (i, line) in self.input.lines().enumerate() {
+        // Use split_terminator instead of lines so that if there is a `\r`,
+        // it is included in the offset calculation. The `+1` values below
+        // account for the `\n`.
+        for (i, line) in self.input.split_terminator('\n').enumerate() {
             if cur + line.len() + 1 > offset {
                 return (i, offset - cur);
             }

--- a/test-suite/tests/de-errors.rs
+++ b/test-suite/tests/de-errors.rs
@@ -323,3 +323,30 @@ fn serde_derive_deserialize_errors() {
         "invalid type: integer `1`, expected a string for key `p_b` at line 4 column 34"
     );
 }
+
+#[test]
+fn error_handles_crlf() {
+    bad!(
+        "\r\n\
+        [t1]\r\n\
+        [t2]\r\n\
+        a = 1\r\n\
+        a = 2\r\n\
+        ",
+        toml::Value,
+        "duplicate key: `a` for key `t2` at line 3 column 1"
+    );
+
+    // Should be the same as above.
+    bad!(
+        "\n\
+        [t1]\n\
+        [t2]\n\
+        a = 1\n\
+        a = 2\n\
+        ",
+        toml::Value,
+        "duplicate key: `a` for key `t2` at line 3 column 1"
+    );
+
+}


### PR DESCRIPTION
The new exposure to line/col in errors uncovered an issue with how `to_linecol` was computing the line/col with a CRLF document. It was not including the CR characters in the offset computation, causing the result to skew for each line.
