### PR TITLE
Fix clippy warnings and errors

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -40,8 +40,8 @@ pub struct DatetimeParseError {
 //
 // In general the TOML encoder/decoder will catch this and not literally emit
 // these strings but rather emit datetimes as they're intended.
-pub const FIELD: &'static str = "$__toml_private_datetime";
-pub const NAME: &'static str = "$__toml_private_Datetime";
+pub const FIELD: &str = "$__toml_private_datetime";
+pub const NAME: &str = "$__toml_private_Datetime";
 
 #[derive(PartialEq, Clone)]
 struct Date {
@@ -135,10 +135,10 @@ impl FromStr for Datetime {
             offset_allowed = false;
             None
         } else {
-            let y1 = digit(&mut chars)? as u16;
-            let y2 = digit(&mut chars)? as u16;
-            let y3 = digit(&mut chars)? as u16;
-            let y4 = digit(&mut chars)? as u16;
+            let y1 = u16::from(digit(&mut chars)?);
+            let y2 = u16::from(digit(&mut chars)?);
+            let y3 = u16::from(digit(&mut chars)?);
+            let y4 = u16::from(digit(&mut chars)?);
 
             match chars.next() {
                 Some('-') => {}
@@ -210,7 +210,7 @@ impl FromStr for Datetime {
                         b'0'..=b'9' => {
                             if i < 9 {
                                 let p = 10_u32.pow(8 - i as u32);
-                                nanosecond += p * (byte - b'0') as u32;
+                                nanosecond += p * u32::from(byte - b'0');
                             }
                         }
                         _ => {
@@ -229,7 +229,7 @@ impl FromStr for Datetime {
                 hour: h1 * 10 + h2,
                 minute: m1 * 10 + m2,
                 second: s1 * 10 + s2,
-                nanosecond: nanosecond,
+                nanosecond,
             };
 
             if time.hour > 24 {
@@ -292,8 +292,8 @@ impl FromStr for Datetime {
 
         Ok(Datetime {
             date: full_date,
-            time: time,
-            offset: offset,
+            time,
+            offset,
         })
     }
 }
@@ -345,7 +345,7 @@ impl<'de> de::Deserialize<'de> for Datetime {
             }
         }
 
-        static FIELDS: [&'static str; 1] = [FIELD];
+        static FIELDS: [&str; 1] = [FIELD];
         deserializer.deserialize_struct(NAME, &FIELDS, DatetimeVisitor)
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -150,8 +150,8 @@ impl Map<String, Value> {
         use std::collections::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
-            EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant: vacant }),
-            EntryImpl::Occupied(occupied) => Entry::Occupied(OccupiedEntry { occupied: occupied }),
+            EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant }),
+            EntryImpl::Occupied(occupied) => Entry::Occupied(OccupiedEntry { occupied }),
         }
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -25,6 +25,8 @@
 //! # fn main() {}
 //! ```
 
+#![allow(unused_must_use)]
+
 use std::cell::Cell;
 use std::error;
 use std::fmt::{self, Write};
@@ -422,7 +424,7 @@ impl<'a> Serializer<'a> {
 
     fn display<T: fmt::Display>(&mut self, t: T, type_: &'static str) -> Result<(), Error> {
         self.emit_key(type_)?;
-        drop(write!(self.dst, "{}", t));
+        write!(self.dst, "{}", t);
         if let State::Table { .. } = self.state {
             self.dst.push_str("\n");
         }
@@ -515,7 +517,7 @@ impl<'a> Serializer<'a> {
             _ => false,
         });
         if ok {
-            drop(write!(self.dst, "{}", key));
+            write!(self.dst, "{}", key);
         } else {
             self.emit_str(key, true)?;
         }
@@ -647,7 +649,9 @@ impl<'a> Serializer<'a> {
                         '\u{d}' => self.dst.push_str("\\r"),
                         '\u{22}' => self.dst.push_str("\\\""),
                         '\u{5c}' => self.dst.push_str("\\\\"),
-                        c if c < '\u{1f}' => drop(write!(self.dst, "\\u{:04X}", ch as u32)),
+                        c if c < '\u{1f}' => {
+                            write!(self.dst, "\\u{:04X}", ch as u32);
+                        }
                         ch => self.dst.push(ch),
                     }
                 }
@@ -750,15 +754,15 @@ macro_rules! serialize_float {
     ($this:expr, $v:expr) => {{
         $this.emit_key("float")?;
         if ($v.is_nan() || $v == 0.0) && $v.is_sign_negative() {
-            drop(write!($this.dst, "-"));
+            write!($this.dst, "-");
         }
         if $v.is_nan() {
-            drop(write!($this.dst, "nan"));
+            write!($this.dst, "nan");
         } else {
-            drop(write!($this.dst, "{}", $v));
+            write!($this.dst, "{}", $v);
         }
         if $v % 1.0 == 0.0 {
-            drop(write!($this.dst, ".0"));
+            write!($this.dst, ".0");
         }
         if let State::Table { .. } = $this.state {
             $this.dst.push_str("\n");

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -247,7 +247,7 @@ impl<'a> Serializer<'a> {
     /// will be present in `dst`.
     pub fn new(dst: &'a mut String) -> Serializer<'a> {
         Serializer {
-            dst: dst,
+            dst,
             state: State::End,
             settings: Rc::new(Settings::default()),
         }
@@ -263,7 +263,7 @@ impl<'a> Serializer<'a> {
     ///   have a trailing comma. See `Serializer::pretty_array`
     pub fn pretty(dst: &'a mut String) -> Serializer<'a> {
         Serializer {
-            dst: dst,
+            dst,
             state: State::End,
             settings: Rc::new(Settings {
                 array: Some(ArraySettings::pretty()),
@@ -331,13 +331,12 @@ impl<'a> Serializer<'a> {
     /// """
     /// ```
     pub fn pretty_string_literal(&mut self, value: bool) -> &mut Self {
-        let use_default =
-            if let &mut Some(ref mut s) = &mut Rc::get_mut(&mut self.settings).unwrap().string {
-                s.literal = value;
-                false
-            } else {
-                true
-            };
+        let use_default = if let Some(ref mut s) = Rc::get_mut(&mut self.settings).unwrap().string {
+            s.literal = value;
+            false
+        } else {
+            true
+        };
 
         if use_default {
             let mut string = StringSettings::pretty();
@@ -387,13 +386,12 @@ impl<'a> Serializer<'a> {
     ///
     /// See `Serializer::pretty_array` for more details.
     pub fn pretty_array_indent(&mut self, value: usize) -> &mut Self {
-        let use_default =
-            if let &mut Some(ref mut a) = &mut Rc::get_mut(&mut self.settings).unwrap().array {
-                a.indent = value;
-                false
-            } else {
-                true
-            };
+        let use_default = if let Some(ref mut a) = Rc::get_mut(&mut self.settings).unwrap().array {
+            a.indent = value;
+            false
+        } else {
+            true
+        };
 
         if use_default {
             let mut array = ArraySettings::pretty();
@@ -407,13 +405,12 @@ impl<'a> Serializer<'a> {
     ///
     /// See `Serializer::pretty_array` for more details.
     pub fn pretty_array_trailing_comma(&mut self, value: bool) -> &mut Self {
-        let use_default =
-            if let &mut Some(ref mut a) = &mut Rc::get_mut(&mut self.settings).unwrap().array {
-                a.trailing_comma = value;
-                false
-            } else {
-                true
-            };
+        let use_default = if let Some(ref mut a) = Rc::get_mut(&mut self.settings).unwrap().array {
+            a.trailing_comma = value;
+            false
+        } else {
+            true
+        };
 
         if use_default {
             let mut array = ArraySettings::pretty();
@@ -610,7 +607,7 @@ impl<'a> Serializer<'a> {
                 (&Some(StringSettings { literal: false, .. }), Repr::Literal(_, ty)) => {
                     Repr::Std(ty)
                 }
-                (_, r @ _) => r,
+                (_, r) => r,
             }
         } else {
             Repr::Std(Type::OnelineSingle)
@@ -902,7 +899,7 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
             ser: self,
             first: Cell::new(true),
             type_: Cell::new(None),
-            len: len,
+            len,
         })
     }
 
@@ -1099,10 +1096,10 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
                 let res = value.serialize(&mut Serializer {
                     dst: &mut *ser.dst,
                     state: State::Table {
-                        key: key,
+                        key,
                         parent: &ser.state,
-                        first: first,
-                        table_emitted: table_emitted,
+                        first,
+                        table_emitted,
                     },
                     settings: ser.settings.clone(),
                 });
@@ -1155,10 +1152,10 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
                 let res = value.serialize(&mut Serializer {
                     dst: &mut *ser.dst,
                     state: State::Table {
-                        key: key,
+                        key,
                         parent: &ser.state,
-                        first: first,
-                        table_emitted: table_emitted,
+                        first,
+                        table_emitted,
                     },
                     settings: ser.settings.clone(),
                 });

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -25,8 +25,6 @@
 //! # fn main() {}
 //! ```
 
-#![allow(unused_must_use)]
-
 use std::cell::Cell;
 use std::error;
 use std::fmt::{self, Write};
@@ -424,7 +422,7 @@ impl<'a> Serializer<'a> {
 
     fn display<T: fmt::Display>(&mut self, t: T, type_: &'static str) -> Result<(), Error> {
         self.emit_key(type_)?;
-        write!(self.dst, "{}", t);
+        write!(self.dst, "{}", t).map_err(ser::Error::custom)?;
         if let State::Table { .. } = self.state {
             self.dst.push_str("\n");
         }
@@ -517,7 +515,7 @@ impl<'a> Serializer<'a> {
             _ => false,
         });
         if ok {
-            write!(self.dst, "{}", key);
+            write!(self.dst, "{}", key).map_err(ser::Error::custom)?;
         } else {
             self.emit_str(key, true)?;
         }
@@ -650,7 +648,7 @@ impl<'a> Serializer<'a> {
                         '\u{22}' => self.dst.push_str("\\\""),
                         '\u{5c}' => self.dst.push_str("\\\\"),
                         c if c < '\u{1f}' => {
-                            write!(self.dst, "\\u{:04X}", ch as u32);
+                            write!(self.dst, "\\u{:04X}", ch as u32).map_err(ser::Error::custom)?;
                         }
                         ch => self.dst.push(ch),
                     }
@@ -754,15 +752,15 @@ macro_rules! serialize_float {
     ($this:expr, $v:expr) => {{
         $this.emit_key("float")?;
         if ($v.is_nan() || $v == 0.0) && $v.is_sign_negative() {
-            write!($this.dst, "-");
+            write!($this.dst, "-").map_err(ser::Error::custom)?;
         }
         if $v.is_nan() {
-            write!($this.dst, "nan");
+            write!($this.dst, "nan").map_err(ser::Error::custom)?;
         } else {
-            write!($this.dst, "{}", $v);
+            write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
         }
         if $v % 1.0 == 0.0 {
-            write!($this.dst, ".0");
+            write!($this.dst, ".0").map_err(ser::Error::custom)?;
         }
         if let State::Table { .. } = $this.state {
             $this.dst.push_str("\n");

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -2,13 +2,13 @@ use serde::{de, ser};
 use std::fmt;
 
 #[doc(hidden)]
-pub const NAME: &'static str = "$__toml_private_Spanned";
+pub const NAME: &str = "$__toml_private_Spanned";
 #[doc(hidden)]
-pub const START: &'static str = "$__toml_private_start";
+pub const START: &str = "$__toml_private_start";
 #[doc(hidden)]
-pub const END: &'static str = "$__toml_private_end";
+pub const END: &str = "$__toml_private_end";
 #[doc(hidden)]
-pub const VALUE: &'static str = "$__toml_private_value";
+pub const VALUE: &str = "$__toml_private_value";
 
 /// A spanned value, indicating the range at which it is defined in the source.
 ///
@@ -116,17 +116,13 @@ where
 
                 let value: T = visitor.next_value()?;
 
-                Ok(Spanned {
-                    start: start,
-                    end: end,
-                    value: value,
-                })
+                Ok(Spanned { start, end, value })
             }
         }
 
         let visitor = SpannedVisitor(::std::marker::PhantomData);
 
-        static FIELDS: [&'static str; 3] = [START, END, VALUE];
+        static FIELDS: [&str; 3] = [START, END, VALUE];
         deserializer.deserialize_struct(NAME, &FIELDS, visitor)
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -84,7 +84,7 @@ enum MaybeString {
 impl<'a> Tokenizer<'a> {
     pub fn new(input: &'a str) -> Tokenizer<'a> {
         let mut t = Tokenizer {
-            input: input,
+            input,
             chars: CrlfFold {
                 chars: input.char_indices(),
             },
@@ -266,7 +266,7 @@ impl<'a> Tokenizer<'a> {
             .clone()
             .next()
             .map(|i| i.0)
-            .unwrap_or(self.input.len())
+            .unwrap_or_else(|| self.input.len())
     }
 
     pub fn input(&self) -> &'a str {
@@ -349,7 +349,7 @@ impl<'a> Tokenizer<'a> {
                     return Ok(String {
                         src: &self.input[start..self.current()],
                         val: val.into_cow(&self.input[..i]),
-                        multiline: multiline,
+                        multiline,
                     });
                 }
                 Some((i, c)) => new_ch(self, &mut val, multiline, i, c)?,
@@ -463,10 +463,7 @@ impl<'a> Tokenizer<'a> {
             .peek_one()
             .map(|t| t.0)
             .unwrap_or_else(|| self.input.len());
-        Span {
-            start: start,
-            end: end,
-        }
+        Span { start, end }
     }
 
     /// Peek one char without consuming it.
@@ -642,7 +639,7 @@ mod tests {
         err(r#""\U00""#, Error::InvalidHexEscape(5, '"'));
         err(r#""\U00"#, Error::UnterminatedString(0));
         err(r#""\uD800"#, Error::InvalidEscapeValue(2, 0xd800));
-        err(r#""\UFFFFFFFF"#, Error::InvalidEscapeValue(2, 0xffffffff));
+        err(r#""\UFFFFFFFF"#, Error::InvalidEscapeValue(2, 0xffff_ffff));
     }
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -749,7 +749,7 @@ impl ser::Serializer for Serializer {
     }
 
     fn serialize_i64(self, value: i64) -> Result<Value, crate::ser::Error> {
-        Ok(Value::Integer(value.into()))
+        Ok(Value::Integer(value))
     }
 
     fn serialize_u8(self, value: u8) -> Result<Value, crate::ser::Error> {


### PR DESCRIPTION
Hi,

Trying to resolve issue #139 and hit a roadblock when it comes to how to handle certain situations. A majority of the warnings and errors have been resolved. I have 1 remaining warning and a question revolving around the use of `drop` in `src/ser.rs`.

Firstly, the one remaining warning

```
warning: methods called `to_*` usually take self by reference; consider choosing a less ambiguous name
   --> src/tokens.rs:505:17
    |
505 |     fn to_owned(&mut self, input: &str) {
    |                 ^^^^^^^^^
    |
    = note: `#[warn(clippy::wrong_self_convention)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```
Personally, I think that the name of the method properly describes the purpose. Just to entertain it what would be a better name?

## Drop

Drop is used frequently in `src/ser.rs` on `Results`, which caused errors for Clippy, but I'm not sure how to properly handle that. Right now, I have a plausible solution, but that just ignores the result. Should the error properly result in a warning message? How do you think this should be handled?

Thanks in advance I really appreciate it :smile: 