### PR TITLE
Allow zero-prefixed float exponents.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1436,11 +1436,11 @@ impl<'a> Deserializer<'a> {
             let (a, b) = if suffix.len() == 1 {
                 self.eat(Token::Plus)?;
                 match self.next()? {
-                    Some((_, Token::Keylike(s))) => self.parse_integer(s, false, false, 10)?,
+                    Some((_, Token::Keylike(s))) => self.parse_integer(s, false, true, 10)?,
                     _ => return Err(self.error(start, ErrorKind::NumberInvalid)),
                 }
             } else {
-                self.parse_integer(&suffix[1..], true, false, 10)?
+                self.parse_integer(&suffix[1..], true, true, 10)?
             };
             if b != "" {
                 return Err(self.error(start, ErrorKind::NumberInvalid));

--- a/test-suite/tests/parser.rs
+++ b/test-suite/tests/parser.rs
@@ -270,7 +270,6 @@ fn bad_floats() {
     bad!("a = 0.0e", "invalid number at line 1 column 5");
     bad!("a = 0.0e-", "invalid number at line 1 column 9");
     bad!("a = 0.0e+", "invalid number at line 1 column 5");
-    bad!("a = 0.0e+00", "invalid number at line 1 column 11");
 }
 
 #[test]

--- a/test-suite/tests/valid.rs
+++ b/test-suite/tests/valid.rs
@@ -368,3 +368,9 @@ test!(
     include_str!("valid/quote-surrounded-value.toml"),
     include_str!("valid/quote-surrounded-value.json")
 );
+
+test!(
+    float_exponent,
+    include_str!("valid/float-exponent.toml"),
+    include_str!("valid/float-exponent.json")
+);

--- a/test-suite/tests/valid/float-exponent.json
+++ b/test-suite/tests/valid/float-exponent.json
@@ -1,0 +1,11 @@
+{
+    "lower": {"type": "float", "value": "300.0"},
+    "upper": {"type": "float", "value": "300.0"},
+    "neg": {"type": "float", "value": "0.03"},
+    "pos": {"type": "float", "value": "300.0"},
+    "zero": {"type": "float", "value": "3.0"},
+    "pointlower": {"type": "float", "value": "310.0"},
+    "pointupper": {"type": "float", "value": "310.0"},
+    "prefix-zero-exp": {"type": "float", "value": "1000000.0"},
+    "prefix-zero-exp-plus": {"type": "float", "value": "1000000.0"}
+}

--- a/test-suite/tests/valid/float-exponent.toml
+++ b/test-suite/tests/valid/float-exponent.toml
@@ -1,0 +1,9 @@
+lower = 3e2
+upper = 3E2
+neg = 3e-2
+pos = 3E+2
+zero = 3e0
+pointlower = 3.1e2
+pointupper = 3.1E2
+prefix-zero-exp = 1e06
+prefix-zero-exp-plus = 1e+06


### PR DESCRIPTION
Zero-prefixed exponents were added in https://github.com/toml-lang/toml/pull/656.