### PR TITLE
Add a spanned value 

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -558,6 +558,36 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
         visitor.visit_newtype_struct(self)
     }
 
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if name == spanned::NAME && fields == [spanned::START, spanned::END, spanned::VALUE] {
+            // TODO we can't actually emit spans here for the *entire* table/array
+            // due to the format that toml uses. Setting the start and end to 0 is
+            // *detectable* (and no reasonable span would look like that),
+            // it would be better to expose this in the API via proper
+            // ADTs like Option<T>.
+            let start = 0;
+            let end = 0;
+
+            let res = visitor.visit_map(SpannedDeserializer {
+                phantom_data: PhantomData,
+                start: Some(start),
+                value: Some(self),
+                end: Some(end),
+            });
+            return res;
+        }
+
+        self.deserialize_any(visitor)
+    }
+
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
@@ -591,7 +621,7 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
 
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map struct unit identifier
+        bytes byte_buf map unit identifier
         ignored_any unit_struct tuple_struct tuple
     }
 }
@@ -850,6 +880,14 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map unit identifier
         ignored_any unit_struct tuple_struct tuple
+    }
+}
+
+impl<'de, 'b> de::IntoDeserializer<'de, Error> for MapVisitor<'de, 'b> {
+    type Deserializer = MapVisitor<'de, 'b>;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@
 
 pub mod map;
 pub mod value;
+pub mod spanned_value;
 #[doc(no_inline)]
 pub use crate::value::Value;
 mod datetime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,10 @@
 #![warn(rust_2018_idioms)]
 
 pub mod map;
-pub mod value;
 pub mod spanned_value;
+pub mod value;
+#[doc(no_inline)]
+pub use crate::spanned_value::SpannedValue;
 #[doc(no_inline)]
 pub use crate::value::Value;
 mod datetime;

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,5 +1,7 @@
 use serde::{de, ser};
 use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::cmp::Ordering;
 
 pub(crate) const NAME: &str = "$__toml_private_Spanned";
 pub(crate) const START: &str = "$__toml_private_start";
@@ -28,7 +30,7 @@ pub(crate) const VALUE: &str = "$__toml_private_value";
 ///     assert_eq!(u.s.into_inner(), String::from("value"));
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Spanned<T> {
     /// The start range.
     start: usize,
@@ -67,6 +69,32 @@ impl<T> Spanned<T> {
     /// Returns a mutable reference to the contained value.
     pub fn get_mut(&self) -> &T {
         &self.value
+    }
+}
+
+impl<T: PartialEq> PartialEq for Spanned<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+impl<T: Eq> Eq for Spanned<T> {}
+
+impl<T: Hash> Hash for Spanned<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for Spanned<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<T: Ord> Ord for Spanned<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
     }
 }
 

--- a/src/spanned_value.rs
+++ b/src/spanned_value.rs
@@ -1,0 +1,1080 @@
+//! Definition of a TOML value
+
+use std::collections::{BTreeMap, HashMap};
+use std::fmt;
+use std::hash::Hash;
+use std::mem::discriminant;
+use std::ops;
+use std::str::FromStr;
+use std::vec;
+
+use serde::de;
+use serde::de::IntoDeserializer;
+use serde::ser;
+
+use crate::datetime::{self, DatetimeFromString};
+pub use crate::datetime::{Datetime, DatetimeParseError};
+
+pub use crate::map::Map;
+
+/// Representation of a TOML value.
+#[derive(PartialEq, Clone, Debug)]
+pub enum Value {
+    /// Represents a TOML string
+    String(String),
+    /// Represents a TOML integer
+    Integer(i64),
+    /// Represents a TOML float
+    Float(f64),
+    /// Represents a TOML boolean
+    Boolean(bool),
+    /// Represents a TOML datetime
+    Datetime(Datetime),
+    /// Represents a TOML array
+    Array(Array),
+    /// Represents a TOML table
+    Table(Table),
+}
+
+/// Type representing a TOML array, payload of the `Value::Array` variant
+pub type Array = Vec<Value>;
+
+/// Type representing a TOML table, payload of the `Value::Table` variant.
+/// By default it is backed by a BTreeMap, enable the `preserve_order` feature
+/// to use a LinkedHashMap instead.
+pub type Table = Map<String, Value>;
+
+impl Value {
+    /// Convert a `T` into `toml::Value` which is an enum that can represent
+    /// any valid TOML data.
+    ///
+    /// This conversion can fail if `T`'s implementation of `Serialize` decides to
+    /// fail, or if `T` contains a map with non-string keys.
+    pub fn try_from<T>(value: T) -> Result<Value, crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        value.serialize(Serializer)
+    }
+
+    /// Interpret a `toml::Value` as an instance of type `T`.
+    ///
+    /// This conversion can fail if the structure of the `Value` does not match the
+    /// structure expected by `T`, for example if `T` is a struct type but the
+    /// `Value` contains something other than a TOML table. It can also fail if the
+    /// structure is correct but `T`'s implementation of `Deserialize` decides that
+    /// something is wrong with the data, for example required struct fields are
+    /// missing from the TOML map or some number is too big to fit in the expected
+    /// primitive type.
+    pub fn try_into<'de, T>(self) -> Result<T, crate::de::Error>
+    where
+        T: de::Deserialize<'de>,
+    {
+        de::Deserialize::deserialize(self)
+    }
+
+    /// Index into a TOML array or map. A string index can be used to access a
+    /// value in a map, and a usize index can be used to access an element of an
+    /// array.
+    ///
+    /// Returns `None` if the type of `self` does not match the type of the
+    /// index, for example if the index is a string and `self` is an array or a
+    /// number. Also returns `None` if the given key does not exist in the map
+    /// or the given index is not within the bounds of the array.
+    pub fn get<I: Index>(&self, index: I) -> Option<&Value> {
+        index.index(self)
+    }
+
+    /// Mutably index into a TOML array or map. A string index can be used to
+    /// access a value in a map, and a usize index can be used to access an
+    /// element of an array.
+    ///
+    /// Returns `None` if the type of `self` does not match the type of the
+    /// index, for example if the index is a string and `self` is an array or a
+    /// number. Also returns `None` if the given key does not exist in the map
+    /// or the given index is not within the bounds of the array.
+    pub fn get_mut<I: Index>(&mut self, index: I) -> Option<&mut Value> {
+        index.index_mut(self)
+    }
+
+    /// Extracts the integer value if it is an integer.
+    pub fn as_integer(&self) -> Option<i64> {
+        match *self {
+            Value::Integer(i) => Some(i),
+            _ => None,
+        }
+    }
+
+    /// Tests whether this value is an integer.
+    pub fn is_integer(&self) -> bool {
+        self.as_integer().is_some()
+    }
+
+    /// Extracts the float value if it is a float.
+    pub fn as_float(&self) -> Option<f64> {
+        match *self {
+            Value::Float(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// Tests whether this value is a float.
+    pub fn is_float(&self) -> bool {
+        self.as_float().is_some()
+    }
+
+    /// Extracts the boolean value if it is a boolean.
+    pub fn as_bool(&self) -> Option<bool> {
+        match *self {
+            Value::Boolean(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    /// Tests whether this value is a boolean.
+    pub fn is_bool(&self) -> bool {
+        self.as_bool().is_some()
+    }
+
+    /// Extracts the string of this value if it is a string.
+    pub fn as_str(&self) -> Option<&str> {
+        match *self {
+            Value::String(ref s) => Some(&**s),
+            _ => None,
+        }
+    }
+
+    /// Tests if this value is a string.
+    pub fn is_str(&self) -> bool {
+        self.as_str().is_some()
+    }
+
+    /// Extracts the datetime value if it is a datetime.
+    ///
+    /// Note that a parsed TOML value will only contain ISO 8601 dates. An
+    /// example date is:
+    ///
+    /// ```notrust
+    /// 1979-05-27T07:32:00Z
+    /// ```
+    pub fn as_datetime(&self) -> Option<&Datetime> {
+        match *self {
+            Value::Datetime(ref s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Tests whether this value is a datetime.
+    pub fn is_datetime(&self) -> bool {
+        self.as_datetime().is_some()
+    }
+
+    /// Extracts the array value if it is an array.
+    pub fn as_array(&self) -> Option<&Vec<Value>> {
+        match *self {
+            Value::Array(ref s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Extracts the array value if it is an array.
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
+        match *self {
+            Value::Array(ref mut s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Tests whether this value is an array.
+    pub fn is_array(&self) -> bool {
+        self.as_array().is_some()
+    }
+
+    /// Extracts the table value if it is a table.
+    pub fn as_table(&self) -> Option<&Table> {
+        match *self {
+            Value::Table(ref s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Extracts the table value if it is a table.
+    pub fn as_table_mut(&mut self) -> Option<&mut Table> {
+        match *self {
+            Value::Table(ref mut s) => Some(s),
+            _ => None,
+        }
+    }
+
+    /// Tests whether this value is a table.
+    pub fn is_table(&self) -> bool {
+        self.as_table().is_some()
+    }
+
+    /// Tests whether this and another value have the same type.
+    pub fn same_type(&self, other: &Value) -> bool {
+        discriminant(self) == discriminant(other)
+    }
+
+    /// Returns a human-readable representation of the type of this value.
+    pub fn type_str(&self) -> &'static str {
+        match *self {
+            Value::String(..) => "string",
+            Value::Integer(..) => "integer",
+            Value::Float(..) => "float",
+            Value::Boolean(..) => "boolean",
+            Value::Datetime(..) => "datetime",
+            Value::Array(..) => "array",
+            Value::Table(..) => "table",
+        }
+    }
+}
+
+impl<I> ops::Index<I> for Value
+where
+    I: Index,
+{
+    type Output = Value;
+
+    fn index(&self, index: I) -> &Value {
+        self.get(index).expect("index not found")
+    }
+}
+
+impl<I> ops::IndexMut<I> for Value
+where
+    I: Index,
+{
+    fn index_mut(&mut self, index: I) -> &mut Value {
+        self.get_mut(index).expect("index not found")
+    }
+}
+
+impl<'a> From<&'a str> for Value {
+    #[inline]
+    fn from(val: &'a str) -> Value {
+        Value::String(val.to_string())
+    }
+}
+
+impl<V: Into<Value>> From<Vec<V>> for Value {
+    fn from(val: Vec<V>) -> Value {
+        Value::Array(val.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl<S: Into<String>, V: Into<Value>> From<BTreeMap<S, V>> for Value {
+    fn from(val: BTreeMap<S, V>) -> Value {
+        let table = val.into_iter().map(|(s, v)| (s.into(), v.into())).collect();
+
+        Value::Table(table)
+    }
+}
+
+impl<S: Into<String> + Hash + Eq, V: Into<Value>> From<HashMap<S, V>> for Value {
+    fn from(val: HashMap<S, V>) -> Value {
+        let table = val.into_iter().map(|(s, v)| (s.into(), v.into())).collect();
+
+        Value::Table(table)
+    }
+}
+
+macro_rules! impl_into_value {
+    ($variant:ident : $T:ty) => {
+        impl From<$T> for Value {
+            #[inline]
+            fn from(val: $T) -> Value {
+                Value::$variant(val.into())
+            }
+        }
+    };
+}
+
+impl_into_value!(String: String);
+impl_into_value!(Integer: i64);
+impl_into_value!(Integer: i32);
+impl_into_value!(Integer: i8);
+impl_into_value!(Integer: u8);
+impl_into_value!(Integer: u32);
+impl_into_value!(Float: f64);
+impl_into_value!(Float: f32);
+impl_into_value!(Boolean: bool);
+impl_into_value!(Datetime: Datetime);
+impl_into_value!(Table: Table);
+
+/// Types that can be used to index a `toml::Value`
+///
+/// Currently this is implemented for `usize` to index arrays and `str` to index
+/// tables.
+///
+/// This trait is sealed and not intended for implementation outside of the
+/// `toml` crate.
+pub trait Index: Sealed {
+    #[doc(hidden)]
+    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value>;
+    #[doc(hidden)]
+    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value>;
+}
+
+/// An implementation detail that should not be implemented, this will change in
+/// the future and break code otherwise.
+#[doc(hidden)]
+pub trait Sealed {}
+impl Sealed for usize {}
+impl Sealed for str {}
+impl Sealed for String {}
+impl<'a, T: Sealed + ?Sized> Sealed for &'a T {}
+
+impl Index for usize {
+    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+        match *val {
+            Value::Array(ref a) => a.get(*self),
+            _ => None,
+        }
+    }
+
+    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+        match *val {
+            Value::Array(ref mut a) => a.get_mut(*self),
+            _ => None,
+        }
+    }
+}
+
+impl Index for str {
+    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+        match *val {
+            Value::Table(ref a) => a.get(self),
+            _ => None,
+        }
+    }
+
+    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+        match *val {
+            Value::Table(ref mut a) => a.get_mut(self),
+            _ => None,
+        }
+    }
+}
+
+impl Index for String {
+    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+        self[..].index(val)
+    }
+
+    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+        self[..].index_mut(val)
+    }
+}
+
+impl<'s, T: ?Sized> Index for &'s T
+where
+    T: Index,
+{
+    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+        (**self).index(val)
+    }
+
+    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+        (**self).index_mut(val)
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        crate::ser::to_string(self)
+            .expect("Unable to represent value as string")
+            .fmt(f)
+    }
+}
+
+impl FromStr for Value {
+    type Err = crate::de::Error;
+    fn from_str(s: &str) -> Result<Value, Self::Err> {
+        crate::from_str(s)
+    }
+}
+
+impl ser::Serialize for Value {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        use serde::ser::SerializeMap;
+
+        match *self {
+            Value::String(ref s) => serializer.serialize_str(s),
+            Value::Integer(i) => serializer.serialize_i64(i),
+            Value::Float(f) => serializer.serialize_f64(f),
+            Value::Boolean(b) => serializer.serialize_bool(b),
+            Value::Datetime(ref s) => s.serialize(serializer),
+            Value::Array(ref a) => a.serialize(serializer),
+            Value::Table(ref t) => {
+                let mut map = serializer.serialize_map(Some(t.len()))?;
+                // Be sure to visit non-tables first (and also non
+                // array-of-tables) as all keys must be emitted first.
+                for (k, v) in t {
+                    if !v.is_table() && !v.is_array()
+                        || (v
+                            .as_array()
+                            .map(|a| !a.iter().any(|v| v.is_table()))
+                            .unwrap_or(false))
+                    {
+                        map.serialize_entry(k, v)?;
+                    }
+                }
+                for (k, v) in t {
+                    if v.as_array()
+                        .map(|a| a.iter().any(|v| v.is_table()))
+                        .unwrap_or(false)
+                    {
+                        map.serialize_entry(k, v)?;
+                    }
+                }
+                for (k, v) in t {
+                    if v.is_table() {
+                        map.serialize_entry(k, v)?;
+                    }
+                }
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Value {
+    fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> de::Visitor<'de> for ValueVisitor {
+            type Value = Value;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("any valid TOML value")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Value, E> {
+                Ok(Value::Boolean(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
+                Ok(Value::Integer(value))
+            }
+
+            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Value, E> {
+                if value <= i64::max_value() as u64 {
+                    Ok(Value::Integer(value as i64))
+                } else {
+                    Err(de::Error::custom("u64 value was too large"))
+                }
+            }
+
+            fn visit_u32<E>(self, value: u32) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            fn visit_i32<E>(self, value: i32) -> Result<Value, E> {
+                Ok(Value::Integer(value.into()))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
+                Ok(Value::Float(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Value, E> {
+                Ok(Value::String(value.into()))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Value, E> {
+                Ok(Value::String(value))
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Value, D::Error>
+            where
+                D: de::Deserializer<'de>,
+            {
+                de::Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_seq<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+            {
+                let mut vec = Vec::new();
+                while let Some(elem) = visitor.next_element()? {
+                    vec.push(elem);
+                }
+                Ok(Value::Array(vec))
+            }
+
+            fn visit_map<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut key = String::new();
+                let datetime = visitor.next_key_seed(DatetimeOrTable { key: &mut key })?;
+                match datetime {
+                    Some(true) => {
+                        let date: DatetimeFromString = visitor.next_value()?;
+                        return Ok(Value::Datetime(date.value));
+                    }
+                    None => return Ok(Value::Table(Map::new())),
+                    Some(false) => {}
+                }
+                let mut map = Map::new();
+                map.insert(key, visitor.next_value()?);
+                while let Some(key) = visitor.next_key()? {
+                    if map.contains_key(&key) {
+                        let msg = format!("duplicate key: `{}`", key);
+                        return Err(de::Error::custom(msg));
+                    }
+                    map.insert(key, visitor.next_value()?);
+                }
+                Ok(Value::Table(map))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+impl<'de> de::Deserializer<'de> for Value {
+    type Error = crate::de::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, crate::de::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Value::Boolean(v) => visitor.visit_bool(v),
+            Value::Integer(n) => visitor.visit_i64(n),
+            Value::Float(n) => visitor.visit_f64(n),
+            Value::String(v) => visitor.visit_string(v),
+            Value::Datetime(v) => visitor.visit_string(v.to_string()),
+            Value::Array(v) => {
+                let len = v.len();
+                let mut deserializer = SeqDeserializer::new(v);
+                let seq = visitor.visit_seq(&mut deserializer)?;
+                let remaining = deserializer.iter.len();
+                if remaining == 0 {
+                    Ok(seq)
+                } else {
+                    Err(de::Error::invalid_length(len, &"fewer elements in array"))
+                }
+            }
+            Value::Table(v) => {
+                let len = v.len();
+                let mut deserializer = MapDeserializer::new(v);
+                let map = visitor.visit_map(&mut deserializer)?;
+                let remaining = deserializer.iter.len();
+                if remaining == 0 {
+                    Ok(map)
+                } else {
+                    Err(de::Error::invalid_length(len, &"fewer elements in map"))
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn deserialize_enum<V>(
+        self,
+        _name: &str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, crate::de::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self {
+            Value::String(variant) => visitor.visit_enum(variant.into_deserializer()),
+            _ => Err(de::Error::invalid_type(
+                de::Unexpected::UnitVariant,
+                &"string only",
+            )),
+        }
+    }
+
+    // `None` is interpreted as a missing field so be sure to implement `Some`
+    // as a present field.
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, crate::de::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, crate::de::Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string unit seq
+        bytes byte_buf map unit_struct tuple_struct struct
+        tuple ignored_any identifier
+    }
+}
+
+struct SeqDeserializer {
+    iter: vec::IntoIter<Value>,
+}
+
+impl SeqDeserializer {
+    fn new(vec: Vec<Value>) -> Self {
+        SeqDeserializer {
+            iter: vec.into_iter(),
+        }
+    }
+}
+
+impl<'de> de::SeqAccess<'de> for SeqDeserializer {
+    type Error = crate::de::Error;
+
+    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, crate::de::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some(value) => seed.deserialize(value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+struct MapDeserializer {
+    iter: <Map<String, Value> as IntoIterator>::IntoIter,
+    value: Option<(String, Value)>,
+}
+
+impl MapDeserializer {
+    fn new(map: Map<String, Value>) -> Self {
+        MapDeserializer {
+            iter: map.into_iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for MapDeserializer {
+    type Error = crate::de::Error;
+
+    fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, crate::de::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.value = Some((key.clone(), value));
+                seed.deserialize(Value::String(key)).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    fn next_value_seed<T>(&mut self, seed: T) -> Result<T::Value, crate::de::Error>
+    where
+        T: de::DeserializeSeed<'de>,
+    {
+        let (key, res) = match self.value.take() {
+            Some((key, value)) => (key, seed.deserialize(value)),
+            None => return Err(de::Error::custom("value is missing")),
+        };
+        res.map_err(|mut error| {
+            error.add_key_context(&key);
+            error
+        })
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.iter.size_hint() {
+            (lower, Some(upper)) if lower == upper => Some(upper),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> de::IntoDeserializer<'de, crate::de::Error> for Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self {
+        self
+    }
+}
+
+struct Serializer;
+
+impl ser::Serializer for Serializer {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    type SerializeSeq = SerializeVec;
+    type SerializeTuple = SerializeVec;
+    type SerializeTupleStruct = SerializeVec;
+    type SerializeTupleVariant = SerializeVec;
+    type SerializeMap = SerializeMap;
+    type SerializeStruct = SerializeMap;
+    type SerializeStructVariant = ser::Impossible<Value, crate::ser::Error>;
+
+    fn serialize_bool(self, value: bool) -> Result<Value, crate::ser::Error> {
+        Ok(Value::Boolean(value))
+    }
+
+    fn serialize_i8(self, value: i8) -> Result<Value, crate::ser::Error> {
+        self.serialize_i64(value.into())
+    }
+
+    fn serialize_i16(self, value: i16) -> Result<Value, crate::ser::Error> {
+        self.serialize_i64(value.into())
+    }
+
+    fn serialize_i32(self, value: i32) -> Result<Value, crate::ser::Error> {
+        self.serialize_i64(value.into())
+    }
+
+    fn serialize_i64(self, value: i64) -> Result<Value, crate::ser::Error> {
+        Ok(Value::Integer(value))
+    }
+
+    fn serialize_u8(self, value: u8) -> Result<Value, crate::ser::Error> {
+        self.serialize_i64(value.into())
+    }
+
+    fn serialize_u16(self, value: u16) -> Result<Value, crate::ser::Error> {
+        self.serialize_i64(value.into())
+    }
+
+    fn serialize_u32(self, value: u32) -> Result<Value, crate::ser::Error> {
+        self.serialize_i64(value.into())
+    }
+
+    fn serialize_u64(self, value: u64) -> Result<Value, crate::ser::Error> {
+        if value <= i64::max_value() as u64 {
+            self.serialize_i64(value as i64)
+        } else {
+            Err(ser::Error::custom("u64 value was too large"))
+        }
+    }
+
+    fn serialize_f32(self, value: f32) -> Result<Value, crate::ser::Error> {
+        self.serialize_f64(value.into())
+    }
+
+    fn serialize_f64(self, value: f64) -> Result<Value, crate::ser::Error> {
+        Ok(Value::Float(value))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Value, crate::ser::Error> {
+        let mut s = String::new();
+        s.push(value);
+        self.serialize_str(&s)
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Value, crate::ser::Error> {
+        Ok(Value::String(value.to_owned()))
+    }
+
+    fn serialize_bytes(self, value: &[u8]) -> Result<Value, crate::ser::Error> {
+        let vec = value.iter().map(|&b| Value::Integer(b.into())).collect();
+        Ok(Value::Array(vec))
+    }
+
+    fn serialize_unit(self) -> Result<Value, crate::ser::Error> {
+        Err(crate::ser::Error::UnsupportedType)
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value, crate::ser::Error> {
+        Err(crate::ser::Error::UnsupportedType)
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Value, crate::ser::Error> {
+        self.serialize_str(_variant)
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Value, crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Value, crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        Err(crate::ser::Error::UnsupportedType)
+    }
+
+    fn serialize_none(self) -> Result<Value, crate::ser::Error> {
+        Err(crate::ser::Error::UnsupportedNone)
+    }
+
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Value, crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, crate::ser::Error> {
+        Ok(SerializeVec {
+            vec: Vec::with_capacity(len.unwrap_or(0)),
+        })
+    }
+
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, crate::ser::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleStruct, crate::ser::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeTupleVariant, crate::ser::Error> {
+        self.serialize_seq(Some(len))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, crate::ser::Error> {
+        Ok(SerializeMap {
+            map: Map::new(),
+            next_key: None,
+        })
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        len: usize,
+    ) -> Result<Self::SerializeStruct, crate::ser::Error> {
+        self.serialize_map(Some(len))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, crate::ser::Error> {
+        Err(crate::ser::Error::UnsupportedType)
+    }
+}
+
+struct SerializeVec {
+    vec: Vec<Value>,
+}
+
+struct SerializeMap {
+    map: Map<String, Value>,
+    next_key: Option<String>,
+}
+
+impl ser::SerializeSeq for SerializeVec {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        self.vec.push(Value::try_from(value)?);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, crate::ser::Error> {
+        Ok(Value::Array(self.vec))
+    }
+}
+
+impl ser::SerializeTuple for SerializeVec {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value, crate::ser::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeTupleStruct for SerializeVec {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value, crate::ser::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeTupleVariant for SerializeVec {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeSeq::serialize_element(self, value)
+    }
+
+    fn end(self) -> Result<Value, crate::ser::Error> {
+        ser::SerializeSeq::end(self)
+    }
+}
+
+impl ser::SerializeMap for SerializeMap {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        match Value::try_from(key)? {
+            Value::String(s) => self.next_key = Some(s),
+            _ => return Err(crate::ser::Error::KeyNotString),
+        };
+        Ok(())
+    }
+
+    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        let key = self.next_key.take();
+        let key = key.expect("serialize_value called before serialize_key");
+        match Value::try_from(value) {
+            Ok(value) => {
+                self.map.insert(key, value);
+            }
+            Err(crate::ser::Error::UnsupportedNone) => {}
+            Err(e) => return Err(e),
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Value, crate::ser::Error> {
+        Ok(Value::Table(self.map))
+    }
+}
+
+impl ser::SerializeStruct for SerializeMap {
+    type Ok = Value;
+    type Error = crate::ser::Error;
+
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), crate::ser::Error>
+    where
+        T: ser::Serialize,
+    {
+        ser::SerializeMap::serialize_key(self, key)?;
+        ser::SerializeMap::serialize_value(self, value)
+    }
+
+    fn end(self) -> Result<Value, crate::ser::Error> {
+        ser::SerializeMap::end(self)
+    }
+}
+
+struct DatetimeOrTable<'a> {
+    key: &'a mut String,
+}
+
+impl<'a, 'de> de::DeserializeSeed<'de> for DatetimeOrTable<'a> {
+    type Value = bool;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'a, 'de> de::Visitor<'de> for DatetimeOrTable<'a> {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a string key")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<bool, E>
+    where
+        E: de::Error,
+    {
+        if s == datetime::FIELD {
+            Ok(true)
+        } else {
+            self.key.push_str(s);
+            Ok(false)
+        }
+    }
+
+    fn visit_string<E>(self, s: String) -> Result<bool, E>
+    where
+        E: de::Error,
+    {
+        if s == datetime::FIELD {
+            Ok(true)
+        } else {
+            *self.key = s;
+            Ok(false)
+        }
+    }
+}

--- a/src/spanned_value.rs
+++ b/src/spanned_value.rs
@@ -19,7 +19,7 @@ pub use crate::map::Map;
 
 /// Representation of a TOML value.
 #[derive(PartialEq, Clone, Debug)]
-pub enum Value {
+pub enum ValueKind {
     /// Represents a TOML string
     String(String),
     /// Represents a TOML integer
@@ -36,32 +36,32 @@ pub enum Value {
     Table(Table),
 }
 
-/// Type representing a TOML array, payload of the `Value::Array` variant
-pub type Array = Vec<Value>;
+/// Type representing a TOML array, payload of the `ValueKind::Array` variant
+pub type Array = Vec<ValueKind>;
 
-/// Type representing a TOML table, payload of the `Value::Table` variant.
+/// Type representing a TOML table, payload of the `ValueKind::Table` variant.
 /// By default it is backed by a BTreeMap, enable the `preserve_order` feature
 /// to use a LinkedHashMap instead.
-pub type Table = Map<String, Value>;
+pub type Table = Map<String, ValueKind>;
 
-impl Value {
-    /// Convert a `T` into `toml::Value` which is an enum that can represent
+impl ValueKind {
+    /// Convert a `T` into `toml::ValueKind` which is an enum that can represent
     /// any valid TOML data.
     ///
     /// This conversion can fail if `T`'s implementation of `Serialize` decides to
     /// fail, or if `T` contains a map with non-string keys.
-    pub fn try_from<T>(value: T) -> Result<Value, crate::ser::Error>
+    pub fn try_from<T>(value: T) -> Result<ValueKind, crate::ser::Error>
     where
         T: ser::Serialize,
     {
         value.serialize(Serializer)
     }
 
-    /// Interpret a `toml::Value` as an instance of type `T`.
+    /// Interpret a `toml::ValueKind` as an instance of type `T`.
     ///
-    /// This conversion can fail if the structure of the `Value` does not match the
+    /// This conversion can fail if the structure of the `ValueKind` does not match the
     /// structure expected by `T`, for example if `T` is a struct type but the
-    /// `Value` contains something other than a TOML table. It can also fail if the
+    /// `ValueKind` contains something other than a TOML table. It can also fail if the
     /// structure is correct but `T`'s implementation of `Deserialize` decides that
     /// something is wrong with the data, for example required struct fields are
     /// missing from the TOML map or some number is too big to fit in the expected
@@ -81,7 +81,7 @@ impl Value {
     /// index, for example if the index is a string and `self` is an array or a
     /// number. Also returns `None` if the given key does not exist in the map
     /// or the given index is not within the bounds of the array.
-    pub fn get<I: Index>(&self, index: I) -> Option<&Value> {
+    pub fn get<I: Index>(&self, index: I) -> Option<&ValueKind> {
         index.index(self)
     }
 
@@ -93,14 +93,14 @@ impl Value {
     /// index, for example if the index is a string and `self` is an array or a
     /// number. Also returns `None` if the given key does not exist in the map
     /// or the given index is not within the bounds of the array.
-    pub fn get_mut<I: Index>(&mut self, index: I) -> Option<&mut Value> {
+    pub fn get_mut<I: Index>(&mut self, index: I) -> Option<&mut ValueKind> {
         index.index_mut(self)
     }
 
     /// Extracts the integer value if it is an integer.
     pub fn as_integer(&self) -> Option<i64> {
         match *self {
-            Value::Integer(i) => Some(i),
+            ValueKind::Integer(i) => Some(i),
             _ => None,
         }
     }
@@ -113,7 +113,7 @@ impl Value {
     /// Extracts the float value if it is a float.
     pub fn as_float(&self) -> Option<f64> {
         match *self {
-            Value::Float(f) => Some(f),
+            ValueKind::Float(f) => Some(f),
             _ => None,
         }
     }
@@ -126,7 +126,7 @@ impl Value {
     /// Extracts the boolean value if it is a boolean.
     pub fn as_bool(&self) -> Option<bool> {
         match *self {
-            Value::Boolean(b) => Some(b),
+            ValueKind::Boolean(b) => Some(b),
             _ => None,
         }
     }
@@ -139,7 +139,7 @@ impl Value {
     /// Extracts the string of this value if it is a string.
     pub fn as_str(&self) -> Option<&str> {
         match *self {
-            Value::String(ref s) => Some(&**s),
+            ValueKind::String(ref s) => Some(&**s),
             _ => None,
         }
     }
@@ -159,7 +159,7 @@ impl Value {
     /// ```
     pub fn as_datetime(&self) -> Option<&Datetime> {
         match *self {
-            Value::Datetime(ref s) => Some(s),
+            ValueKind::Datetime(ref s) => Some(s),
             _ => None,
         }
     }
@@ -170,17 +170,17 @@ impl Value {
     }
 
     /// Extracts the array value if it is an array.
-    pub fn as_array(&self) -> Option<&Vec<Value>> {
+    pub fn as_array(&self) -> Option<&Vec<ValueKind>> {
         match *self {
-            Value::Array(ref s) => Some(s),
+            ValueKind::Array(ref s) => Some(s),
             _ => None,
         }
     }
 
     /// Extracts the array value if it is an array.
-    pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<ValueKind>> {
         match *self {
-            Value::Array(ref mut s) => Some(s),
+            ValueKind::Array(ref mut s) => Some(s),
             _ => None,
         }
     }
@@ -193,7 +193,7 @@ impl Value {
     /// Extracts the table value if it is a table.
     pub fn as_table(&self) -> Option<&Table> {
         match *self {
-            Value::Table(ref s) => Some(s),
+            ValueKind::Table(ref s) => Some(s),
             _ => None,
         }
     }
@@ -201,7 +201,7 @@ impl Value {
     /// Extracts the table value if it is a table.
     pub fn as_table_mut(&mut self) -> Option<&mut Table> {
         match *self {
-            Value::Table(ref mut s) => Some(s),
+            ValueKind::Table(ref mut s) => Some(s),
             _ => None,
         }
     }
@@ -212,79 +212,79 @@ impl Value {
     }
 
     /// Tests whether this and another value have the same type.
-    pub fn same_type(&self, other: &Value) -> bool {
+    pub fn same_type(&self, other: &ValueKind) -> bool {
         discriminant(self) == discriminant(other)
     }
 
     /// Returns a human-readable representation of the type of this value.
     pub fn type_str(&self) -> &'static str {
         match *self {
-            Value::String(..) => "string",
-            Value::Integer(..) => "integer",
-            Value::Float(..) => "float",
-            Value::Boolean(..) => "boolean",
-            Value::Datetime(..) => "datetime",
-            Value::Array(..) => "array",
-            Value::Table(..) => "table",
+            ValueKind::String(..) => "string",
+            ValueKind::Integer(..) => "integer",
+            ValueKind::Float(..) => "float",
+            ValueKind::Boolean(..) => "boolean",
+            ValueKind::Datetime(..) => "datetime",
+            ValueKind::Array(..) => "array",
+            ValueKind::Table(..) => "table",
         }
     }
 }
 
-impl<I> ops::Index<I> for Value
+impl<I> ops::Index<I> for ValueKind
 where
     I: Index,
 {
-    type Output = Value;
+    type Output = ValueKind;
 
-    fn index(&self, index: I) -> &Value {
+    fn index(&self, index: I) -> &ValueKind {
         self.get(index).expect("index not found")
     }
 }
 
-impl<I> ops::IndexMut<I> for Value
+impl<I> ops::IndexMut<I> for ValueKind
 where
     I: Index,
 {
-    fn index_mut(&mut self, index: I) -> &mut Value {
+    fn index_mut(&mut self, index: I) -> &mut ValueKind {
         self.get_mut(index).expect("index not found")
     }
 }
 
-impl<'a> From<&'a str> for Value {
+impl<'a> From<&'a str> for ValueKind {
     #[inline]
-    fn from(val: &'a str) -> Value {
-        Value::String(val.to_string())
+    fn from(val: &'a str) -> ValueKind {
+        ValueKind::String(val.to_string())
     }
 }
 
-impl<V: Into<Value>> From<Vec<V>> for Value {
-    fn from(val: Vec<V>) -> Value {
-        Value::Array(val.into_iter().map(|v| v.into()).collect())
+impl<V: Into<ValueKind>> From<Vec<V>> for ValueKind {
+    fn from(val: Vec<V>) -> ValueKind {
+        ValueKind::Array(val.into_iter().map(|v| v.into()).collect())
     }
 }
 
-impl<S: Into<String>, V: Into<Value>> From<BTreeMap<S, V>> for Value {
-    fn from(val: BTreeMap<S, V>) -> Value {
+impl<S: Into<String>, V: Into<ValueKind>> From<BTreeMap<S, V>> for ValueKind {
+    fn from(val: BTreeMap<S, V>) -> ValueKind {
         let table = val.into_iter().map(|(s, v)| (s.into(), v.into())).collect();
 
-        Value::Table(table)
+        ValueKind::Table(table)
     }
 }
 
-impl<S: Into<String> + Hash + Eq, V: Into<Value>> From<HashMap<S, V>> for Value {
-    fn from(val: HashMap<S, V>) -> Value {
+impl<S: Into<String> + Hash + Eq, V: Into<ValueKind>> From<HashMap<S, V>> for ValueKind {
+    fn from(val: HashMap<S, V>) -> ValueKind {
         let table = val.into_iter().map(|(s, v)| (s.into(), v.into())).collect();
 
-        Value::Table(table)
+        ValueKind::Table(table)
     }
 }
 
 macro_rules! impl_into_value {
     ($variant:ident : $T:ty) => {
-        impl From<$T> for Value {
+        impl From<$T> for ValueKind {
             #[inline]
-            fn from(val: $T) -> Value {
-                Value::$variant(val.into())
+            fn from(val: $T) -> ValueKind {
+                ValueKind::$variant(val.into())
             }
         }
     };
@@ -302,7 +302,7 @@ impl_into_value!(Boolean: bool);
 impl_into_value!(Datetime: Datetime);
 impl_into_value!(Table: Table);
 
-/// Types that can be used to index a `toml::Value`
+/// Types that can be used to index a `toml::ValueKind`
 ///
 /// Currently this is implemented for `usize` to index arrays and `str` to index
 /// tables.
@@ -311,9 +311,9 @@ impl_into_value!(Table: Table);
 /// `toml` crate.
 pub trait Index: Sealed {
     #[doc(hidden)]
-    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value>;
+    fn index<'a>(&self, val: &'a ValueKind) -> Option<&'a ValueKind>;
     #[doc(hidden)]
-    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value>;
+    fn index_mut<'a>(&self, val: &'a mut ValueKind) -> Option<&'a mut ValueKind>;
 }
 
 /// An implementation detail that should not be implemented, this will change in
@@ -326,43 +326,43 @@ impl Sealed for String {}
 impl<'a, T: Sealed + ?Sized> Sealed for &'a T {}
 
 impl Index for usize {
-    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+    fn index<'a>(&self, val: &'a ValueKind) -> Option<&'a ValueKind> {
         match *val {
-            Value::Array(ref a) => a.get(*self),
+            ValueKind::Array(ref a) => a.get(*self),
             _ => None,
         }
     }
 
-    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+    fn index_mut<'a>(&self, val: &'a mut ValueKind) -> Option<&'a mut ValueKind> {
         match *val {
-            Value::Array(ref mut a) => a.get_mut(*self),
+            ValueKind::Array(ref mut a) => a.get_mut(*self),
             _ => None,
         }
     }
 }
 
 impl Index for str {
-    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+    fn index<'a>(&self, val: &'a ValueKind) -> Option<&'a ValueKind> {
         match *val {
-            Value::Table(ref a) => a.get(self),
+            ValueKind::Table(ref a) => a.get(self),
             _ => None,
         }
     }
 
-    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+    fn index_mut<'a>(&self, val: &'a mut ValueKind) -> Option<&'a mut ValueKind> {
         match *val {
-            Value::Table(ref mut a) => a.get_mut(self),
+            ValueKind::Table(ref mut a) => a.get_mut(self),
             _ => None,
         }
     }
 }
 
 impl Index for String {
-    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+    fn index<'a>(&self, val: &'a ValueKind) -> Option<&'a ValueKind> {
         self[..].index(val)
     }
 
-    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+    fn index_mut<'a>(&self, val: &'a mut ValueKind) -> Option<&'a mut ValueKind> {
         self[..].index_mut(val)
     }
 }
@@ -371,16 +371,16 @@ impl<'s, T: ?Sized> Index for &'s T
 where
     T: Index,
 {
-    fn index<'a>(&self, val: &'a Value) -> Option<&'a Value> {
+    fn index<'a>(&self, val: &'a ValueKind) -> Option<&'a ValueKind> {
         (**self).index(val)
     }
 
-    fn index_mut<'a>(&self, val: &'a mut Value) -> Option<&'a mut Value> {
+    fn index_mut<'a>(&self, val: &'a mut ValueKind) -> Option<&'a mut ValueKind> {
         (**self).index_mut(val)
     }
 }
 
-impl fmt::Display for Value {
+impl fmt::Display for ValueKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::ser::to_string(self)
             .expect("Unable to represent value as string")
@@ -388,14 +388,14 @@ impl fmt::Display for Value {
     }
 }
 
-impl FromStr for Value {
+impl FromStr for ValueKind {
     type Err = crate::de::Error;
-    fn from_str(s: &str) -> Result<Value, Self::Err> {
+    fn from_str(s: &str) -> Result<ValueKind, Self::Err> {
         crate::from_str(s)
     }
 }
 
-impl ser::Serialize for Value {
+impl ser::Serialize for ValueKind {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -403,13 +403,13 @@ impl ser::Serialize for Value {
         use serde::ser::SerializeMap;
 
         match *self {
-            Value::String(ref s) => serializer.serialize_str(s),
-            Value::Integer(i) => serializer.serialize_i64(i),
-            Value::Float(f) => serializer.serialize_f64(f),
-            Value::Boolean(b) => serializer.serialize_bool(b),
-            Value::Datetime(ref s) => s.serialize(serializer),
-            Value::Array(ref a) => a.serialize(serializer),
-            Value::Table(ref t) => {
+            ValueKind::String(ref s) => serializer.serialize_str(s),
+            ValueKind::Integer(i) => serializer.serialize_i64(i),
+            ValueKind::Float(f) => serializer.serialize_f64(f),
+            ValueKind::Boolean(b) => serializer.serialize_bool(b),
+            ValueKind::Datetime(ref s) => s.serialize(serializer),
+            ValueKind::Array(ref a) => a.serialize(serializer),
+            ValueKind::Table(ref t) => {
                 let mut map = serializer.serialize_map(Some(t.len()))?;
                 // Be sure to visit non-tables first (and also non
                 // array-of-tables) as all keys must be emitted first.
@@ -442,64 +442,64 @@ impl ser::Serialize for Value {
     }
 }
 
-impl<'de> de::Deserialize<'de> for Value {
-    fn deserialize<D>(deserializer: D) -> Result<Value, D::Error>
+impl<'de> de::Deserialize<'de> for ValueKind {
+    fn deserialize<D>(deserializer: D) -> Result<ValueKind, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        struct ValueVisitor;
+        struct ValueKindVisitor;
 
-        impl<'de> de::Visitor<'de> for ValueVisitor {
-            type Value = Value;
+        impl<'de> de::Visitor<'de> for ValueKindVisitor {
+            type Value = ValueKind;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("any valid TOML value")
             }
 
-            fn visit_bool<E>(self, value: bool) -> Result<Value, E> {
-                Ok(Value::Boolean(value))
+            fn visit_bool<E>(self, value: bool) -> Result<ValueKind, E> {
+                Ok(ValueKind::Boolean(value))
             }
 
-            fn visit_i64<E>(self, value: i64) -> Result<Value, E> {
-                Ok(Value::Integer(value))
+            fn visit_i64<E>(self, value: i64) -> Result<ValueKind, E> {
+                Ok(ValueKind::Integer(value))
             }
 
-            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Value, E> {
+            fn visit_u64<E: de::Error>(self, value: u64) -> Result<ValueKind, E> {
                 if value <= i64::max_value() as u64 {
-                    Ok(Value::Integer(value as i64))
+                    Ok(ValueKind::Integer(value as i64))
                 } else {
                     Err(de::Error::custom("u64 value was too large"))
                 }
             }
 
-            fn visit_u32<E>(self, value: u32) -> Result<Value, E> {
-                Ok(Value::Integer(value.into()))
+            fn visit_u32<E>(self, value: u32) -> Result<ValueKind, E> {
+                Ok(ValueKind::Integer(value.into()))
             }
 
-            fn visit_i32<E>(self, value: i32) -> Result<Value, E> {
-                Ok(Value::Integer(value.into()))
+            fn visit_i32<E>(self, value: i32) -> Result<ValueKind, E> {
+                Ok(ValueKind::Integer(value.into()))
             }
 
-            fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
-                Ok(Value::Float(value))
+            fn visit_f64<E>(self, value: f64) -> Result<ValueKind, E> {
+                Ok(ValueKind::Float(value))
             }
 
-            fn visit_str<E>(self, value: &str) -> Result<Value, E> {
-                Ok(Value::String(value.into()))
+            fn visit_str<E>(self, value: &str) -> Result<ValueKind, E> {
+                Ok(ValueKind::String(value.into()))
             }
 
-            fn visit_string<E>(self, value: String) -> Result<Value, E> {
-                Ok(Value::String(value))
+            fn visit_string<E>(self, value: String) -> Result<ValueKind, E> {
+                Ok(ValueKind::String(value))
             }
 
-            fn visit_some<D>(self, deserializer: D) -> Result<Value, D::Error>
+            fn visit_some<D>(self, deserializer: D) -> Result<ValueKind, D::Error>
             where
                 D: de::Deserializer<'de>,
             {
                 de::Deserialize::deserialize(deserializer)
             }
 
-            fn visit_seq<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            fn visit_seq<V>(self, mut visitor: V) -> Result<ValueKind, V::Error>
             where
                 V: de::SeqAccess<'de>,
             {
@@ -507,10 +507,10 @@ impl<'de> de::Deserialize<'de> for Value {
                 while let Some(elem) = visitor.next_element()? {
                     vec.push(elem);
                 }
-                Ok(Value::Array(vec))
+                Ok(ValueKind::Array(vec))
             }
 
-            fn visit_map<V>(self, mut visitor: V) -> Result<Value, V::Error>
+            fn visit_map<V>(self, mut visitor: V) -> Result<ValueKind, V::Error>
             where
                 V: de::MapAccess<'de>,
             {
@@ -519,9 +519,9 @@ impl<'de> de::Deserialize<'de> for Value {
                 match datetime {
                     Some(true) => {
                         let date: DatetimeFromString = visitor.next_value()?;
-                        return Ok(Value::Datetime(date.value));
+                        return Ok(ValueKind::Datetime(date.value));
                     }
-                    None => return Ok(Value::Table(Map::new())),
+                    None => return Ok(ValueKind::Table(Map::new())),
                     Some(false) => {}
                 }
                 let mut map = Map::new();
@@ -533,15 +533,15 @@ impl<'de> de::Deserialize<'de> for Value {
                     }
                     map.insert(key, visitor.next_value()?);
                 }
-                Ok(Value::Table(map))
+                Ok(ValueKind::Table(map))
             }
         }
 
-        deserializer.deserialize_any(ValueVisitor)
+        deserializer.deserialize_any(ValueKindVisitor)
     }
 }
 
-impl<'de> de::Deserializer<'de> for Value {
+impl<'de> de::Deserializer<'de> for ValueKind {
     type Error = crate::de::Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, crate::de::Error>
@@ -549,12 +549,12 @@ impl<'de> de::Deserializer<'de> for Value {
         V: de::Visitor<'de>,
     {
         match self {
-            Value::Boolean(v) => visitor.visit_bool(v),
-            Value::Integer(n) => visitor.visit_i64(n),
-            Value::Float(n) => visitor.visit_f64(n),
-            Value::String(v) => visitor.visit_string(v),
-            Value::Datetime(v) => visitor.visit_string(v.to_string()),
-            Value::Array(v) => {
+            ValueKind::Boolean(v) => visitor.visit_bool(v),
+            ValueKind::Integer(n) => visitor.visit_i64(n),
+            ValueKind::Float(n) => visitor.visit_f64(n),
+            ValueKind::String(v) => visitor.visit_string(v),
+            ValueKind::Datetime(v) => visitor.visit_string(v.to_string()),
+            ValueKind::Array(v) => {
                 let len = v.len();
                 let mut deserializer = SeqDeserializer::new(v);
                 let seq = visitor.visit_seq(&mut deserializer)?;
@@ -565,7 +565,7 @@ impl<'de> de::Deserializer<'de> for Value {
                     Err(de::Error::invalid_length(len, &"fewer elements in array"))
                 }
             }
-            Value::Table(v) => {
+            ValueKind::Table(v) => {
                 let len = v.len();
                 let mut deserializer = MapDeserializer::new(v);
                 let map = visitor.visit_map(&mut deserializer)?;
@@ -590,7 +590,7 @@ impl<'de> de::Deserializer<'de> for Value {
         V: de::Visitor<'de>,
     {
         match self {
-            Value::String(variant) => visitor.visit_enum(variant.into_deserializer()),
+            ValueKind::String(variant) => visitor.visit_enum(variant.into_deserializer()),
             _ => Err(de::Error::invalid_type(
                 de::Unexpected::UnitVariant,
                 &"string only",
@@ -626,11 +626,11 @@ impl<'de> de::Deserializer<'de> for Value {
 }
 
 struct SeqDeserializer {
-    iter: vec::IntoIter<Value>,
+    iter: vec::IntoIter<ValueKind>,
 }
 
 impl SeqDeserializer {
-    fn new(vec: Vec<Value>) -> Self {
+    fn new(vec: Vec<ValueKind>) -> Self {
         SeqDeserializer {
             iter: vec.into_iter(),
         }
@@ -659,12 +659,12 @@ impl<'de> de::SeqAccess<'de> for SeqDeserializer {
 }
 
 struct MapDeserializer {
-    iter: <Map<String, Value> as IntoIterator>::IntoIter,
-    value: Option<(String, Value)>,
+    iter: <Map<String, ValueKind> as IntoIterator>::IntoIter,
+    value: Option<(String, ValueKind)>,
 }
 
 impl MapDeserializer {
-    fn new(map: Map<String, Value>) -> Self {
+    fn new(map: Map<String, ValueKind>) -> Self {
         MapDeserializer {
             iter: map.into_iter(),
             value: None,
@@ -682,7 +682,7 @@ impl<'de> de::MapAccess<'de> for MapDeserializer {
         match self.iter.next() {
             Some((key, value)) => {
                 self.value = Some((key.clone(), value));
-                seed.deserialize(Value::String(key)).map(Some)
+                seed.deserialize(ValueKind::String(key)).map(Some)
             }
             None => Ok(None),
         }
@@ -710,7 +710,7 @@ impl<'de> de::MapAccess<'de> for MapDeserializer {
     }
 }
 
-impl<'de> de::IntoDeserializer<'de, crate::de::Error> for Value {
+impl<'de> de::IntoDeserializer<'de, crate::de::Error> for ValueKind {
     type Deserializer = Self;
 
     fn into_deserializer(self) -> Self {
@@ -721,7 +721,7 @@ impl<'de> de::IntoDeserializer<'de, crate::de::Error> for Value {
 struct Serializer;
 
 impl ser::Serializer for Serializer {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     type SerializeSeq = SerializeVec;
@@ -730,41 +730,41 @@ impl ser::Serializer for Serializer {
     type SerializeTupleVariant = SerializeVec;
     type SerializeMap = SerializeMap;
     type SerializeStruct = SerializeMap;
-    type SerializeStructVariant = ser::Impossible<Value, crate::ser::Error>;
+    type SerializeStructVariant = ser::Impossible<ValueKind, crate::ser::Error>;
 
-    fn serialize_bool(self, value: bool) -> Result<Value, crate::ser::Error> {
-        Ok(Value::Boolean(value))
+    fn serialize_bool(self, value: bool) -> Result<ValueKind, crate::ser::Error> {
+        Ok(ValueKind::Boolean(value))
     }
 
-    fn serialize_i8(self, value: i8) -> Result<Value, crate::ser::Error> {
+    fn serialize_i8(self, value: i8) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_i64(value.into())
     }
 
-    fn serialize_i16(self, value: i16) -> Result<Value, crate::ser::Error> {
+    fn serialize_i16(self, value: i16) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_i64(value.into())
     }
 
-    fn serialize_i32(self, value: i32) -> Result<Value, crate::ser::Error> {
+    fn serialize_i32(self, value: i32) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_i64(value.into())
     }
 
-    fn serialize_i64(self, value: i64) -> Result<Value, crate::ser::Error> {
-        Ok(Value::Integer(value))
+    fn serialize_i64(self, value: i64) -> Result<ValueKind, crate::ser::Error> {
+        Ok(ValueKind::Integer(value))
     }
 
-    fn serialize_u8(self, value: u8) -> Result<Value, crate::ser::Error> {
+    fn serialize_u8(self, value: u8) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_i64(value.into())
     }
 
-    fn serialize_u16(self, value: u16) -> Result<Value, crate::ser::Error> {
+    fn serialize_u16(self, value: u16) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_i64(value.into())
     }
 
-    fn serialize_u32(self, value: u32) -> Result<Value, crate::ser::Error> {
+    fn serialize_u32(self, value: u32) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_i64(value.into())
     }
 
-    fn serialize_u64(self, value: u64) -> Result<Value, crate::ser::Error> {
+    fn serialize_u64(self, value: u64) -> Result<ValueKind, crate::ser::Error> {
         if value <= i64::max_value() as u64 {
             self.serialize_i64(value as i64)
         } else {
@@ -772,34 +772,34 @@ impl ser::Serializer for Serializer {
         }
     }
 
-    fn serialize_f32(self, value: f32) -> Result<Value, crate::ser::Error> {
+    fn serialize_f32(self, value: f32) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_f64(value.into())
     }
 
-    fn serialize_f64(self, value: f64) -> Result<Value, crate::ser::Error> {
-        Ok(Value::Float(value))
+    fn serialize_f64(self, value: f64) -> Result<ValueKind, crate::ser::Error> {
+        Ok(ValueKind::Float(value))
     }
 
-    fn serialize_char(self, value: char) -> Result<Value, crate::ser::Error> {
+    fn serialize_char(self, value: char) -> Result<ValueKind, crate::ser::Error> {
         let mut s = String::new();
         s.push(value);
         self.serialize_str(&s)
     }
 
-    fn serialize_str(self, value: &str) -> Result<Value, crate::ser::Error> {
-        Ok(Value::String(value.to_owned()))
+    fn serialize_str(self, value: &str) -> Result<ValueKind, crate::ser::Error> {
+        Ok(ValueKind::String(value.to_owned()))
     }
 
-    fn serialize_bytes(self, value: &[u8]) -> Result<Value, crate::ser::Error> {
-        let vec = value.iter().map(|&b| Value::Integer(b.into())).collect();
-        Ok(Value::Array(vec))
+    fn serialize_bytes(self, value: &[u8]) -> Result<ValueKind, crate::ser::Error> {
+        let vec = value.iter().map(|&b| ValueKind::Integer(b.into())).collect();
+        Ok(ValueKind::Array(vec))
     }
 
-    fn serialize_unit(self) -> Result<Value, crate::ser::Error> {
+    fn serialize_unit(self) -> Result<ValueKind, crate::ser::Error> {
         Err(crate::ser::Error::UnsupportedType)
     }
 
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value, crate::ser::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<ValueKind, crate::ser::Error> {
         Err(crate::ser::Error::UnsupportedType)
     }
 
@@ -808,7 +808,7 @@ impl ser::Serializer for Serializer {
         _name: &'static str,
         _variant_index: u32,
         _variant: &'static str,
-    ) -> Result<Value, crate::ser::Error> {
+    ) -> Result<ValueKind, crate::ser::Error> {
         self.serialize_str(_variant)
     }
 
@@ -816,7 +816,7 @@ impl ser::Serializer for Serializer {
         self,
         _name: &'static str,
         value: &T,
-    ) -> Result<Value, crate::ser::Error>
+    ) -> Result<ValueKind, crate::ser::Error>
     where
         T: ser::Serialize,
     {
@@ -829,18 +829,18 @@ impl ser::Serializer for Serializer {
         _variant_index: u32,
         _variant: &'static str,
         _value: &T,
-    ) -> Result<Value, crate::ser::Error>
+    ) -> Result<ValueKind, crate::ser::Error>
     where
         T: ser::Serialize,
     {
         Err(crate::ser::Error::UnsupportedType)
     }
 
-    fn serialize_none(self) -> Result<Value, crate::ser::Error> {
+    fn serialize_none(self) -> Result<ValueKind, crate::ser::Error> {
         Err(crate::ser::Error::UnsupportedNone)
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Value, crate::ser::Error>
+    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<ValueKind, crate::ser::Error>
     where
         T: ser::Serialize,
     {
@@ -902,33 +902,33 @@ impl ser::Serializer for Serializer {
 }
 
 struct SerializeVec {
-    vec: Vec<Value>,
+    vec: Vec<ValueKind>,
 }
 
 struct SerializeMap {
-    map: Map<String, Value>,
+    map: Map<String, ValueKind>,
     next_key: Option<String>,
 }
 
 impl ser::SerializeSeq for SerializeVec {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
     where
         T: ser::Serialize,
     {
-        self.vec.push(Value::try_from(value)?);
+        self.vec.push(ValueKind::try_from(value)?);
         Ok(())
     }
 
-    fn end(self) -> Result<Value, crate::ser::Error> {
-        Ok(Value::Array(self.vec))
+    fn end(self) -> Result<ValueKind, crate::ser::Error> {
+        Ok(ValueKind::Array(self.vec))
     }
 }
 
 impl ser::SerializeTuple for SerializeVec {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
@@ -938,13 +938,13 @@ impl ser::SerializeTuple for SerializeVec {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Value, crate::ser::Error> {
+    fn end(self) -> Result<ValueKind, crate::ser::Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
 impl ser::SerializeTupleStruct for SerializeVec {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
@@ -954,13 +954,13 @@ impl ser::SerializeTupleStruct for SerializeVec {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Value, crate::ser::Error> {
+    fn end(self) -> Result<ValueKind, crate::ser::Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
 impl ser::SerializeTupleVariant for SerializeVec {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), crate::ser::Error>
@@ -970,21 +970,21 @@ impl ser::SerializeTupleVariant for SerializeVec {
         ser::SerializeSeq::serialize_element(self, value)
     }
 
-    fn end(self) -> Result<Value, crate::ser::Error> {
+    fn end(self) -> Result<ValueKind, crate::ser::Error> {
         ser::SerializeSeq::end(self)
     }
 }
 
 impl ser::SerializeMap for SerializeMap {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), crate::ser::Error>
     where
         T: ser::Serialize,
     {
-        match Value::try_from(key)? {
-            Value::String(s) => self.next_key = Some(s),
+        match ValueKind::try_from(key)? {
+            ValueKind::String(s) => self.next_key = Some(s),
             _ => return Err(crate::ser::Error::KeyNotString),
         };
         Ok(())
@@ -996,7 +996,7 @@ impl ser::SerializeMap for SerializeMap {
     {
         let key = self.next_key.take();
         let key = key.expect("serialize_value called before serialize_key");
-        match Value::try_from(value) {
+        match ValueKind::try_from(value) {
             Ok(value) => {
                 self.map.insert(key, value);
             }
@@ -1006,13 +1006,13 @@ impl ser::SerializeMap for SerializeMap {
         Ok(())
     }
 
-    fn end(self) -> Result<Value, crate::ser::Error> {
-        Ok(Value::Table(self.map))
+    fn end(self) -> Result<ValueKind, crate::ser::Error> {
+        Ok(ValueKind::Table(self.map))
     }
 }
 
 impl ser::SerializeStruct for SerializeMap {
-    type Ok = Value;
+    type Ok = ValueKind;
     type Error = crate::ser::Error;
 
     fn serialize_field<T: ?Sized>(
@@ -1027,7 +1027,7 @@ impl ser::SerializeStruct for SerializeMap {
         ser::SerializeMap::serialize_value(self, value)
     }
 
-    fn end(self) -> Result<Value, crate::ser::Error> {
+    fn end(self) -> Result<ValueKind, crate::ser::Error> {
         ser::SerializeMap::end(self)
     }
 }

--- a/test-suite/tests/spanned_value.rs
+++ b/test-suite/tests/spanned_value.rs
@@ -1,0 +1,126 @@
+extern crate toml;
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use toml::spanned_value::ValueKind as K;
+use toml::value::Datetime;
+use toml::SpannedValue;
+
+/// A set of good datetimes.
+pub fn good_datetimes() -> Vec<&'static str> {
+    let mut v = Vec::new();
+    v.push("1997-09-09T09:09:09Z");
+    v.push("1997-09-09T09:09:09+09:09");
+    v.push("1997-09-09T09:09:09-09:09");
+    v.push("1997-09-09T09:09:09");
+    v.push("1997-09-09");
+    v.push("09:09:09");
+    v.push("1997-09-09T09:09:09.09Z");
+    v.push("1997-09-09T09:09:09.09+09:09");
+    v.push("1997-09-09T09:09:09.09-09:09");
+    v.push("1997-09-09T09:09:09.09");
+    v.push("09:09:09.09");
+    v
+}
+
+#[test]
+fn test_spanned_field() {
+    fn good<'de, T>(s: &'de str, expected: &str)
+    where
+        T: serde::Deserialize<'de>,
+    {
+        let foo: SpannedValue = toml::from_str(s).unwrap();
+
+        let foo = &foo.get_ref()["foo"];
+
+        assert_eq!(6, foo.start());
+        assert_eq!(s.len(), foo.end());
+        assert_eq!(expected, &s[foo.start()..foo.end()]);
+    }
+
+    good::<String>("foo = \"foo\"", "\"foo\"");
+    good::<u32>("foo = 42", "42");
+    // leading plus
+    good::<u32>("foo = +42", "+42");
+    // table
+    good::<HashMap<String, u32>>(
+        "foo = {\"foo\" = 42, \"bar\" = 42}",
+        "{\"foo\" = 42, \"bar\" = 42}",
+    );
+    // array
+    good::<Vec<u32>>("foo = [0, 1, 2, 3, 4]", "[0, 1, 2, 3, 4]");
+    // datetime
+    good::<String>("foo = \"1997-09-09T09:09:09Z\"", "\"1997-09-09T09:09:09Z\"");
+
+    for expected in good_datetimes() {
+        let s = format!("foo = {}", expected);
+        good::<Datetime>(&s, expected);
+    }
+}
+
+#[test]
+fn test_spanned_vals() {
+    fn assert_span_subspan(outer: (usize, usize), inner: (usize, usize)) {
+        if outer == (0, 0) || inner == (0, 0) {
+            // One of the spans is not available.
+            // In the general case, the toml format doesn't allow valid spans
+            // to be created for dotted tables as well as arrays
+            // that use [[]] syntax
+            return;
+        }
+        // Allow the inner span to start xor end at the same place
+        // as the outer one
+        assert!((inner.1 - inner.0) < (outer.1 - outer.0));
+        assert!(outer.0 <= inner.0);
+        assert!(inner.1 <= outer.1);
+    }
+    fn visit(val: &SpannedValue, s: &str) {
+        let substr = &s[val.start()..val.end()];
+        match val.get_ref() {
+            K::Array(_) | K::Table(_) => {}
+            K::String(c) => assert_eq!(format!("\"{}\"", c), substr),
+            K::Integer(c) => assert_eq!(Ok(c.clone()), i64::from_str_radix(substr, 10)),
+            K::Float(c) => assert_eq!(Ok(c.clone()), f64::from_str(substr)),
+            K::Boolean(c) => assert_eq!(format!("{}", c), substr.to_lowercase()),
+            K::Datetime(c) => {
+                let dt = Datetime::from_str(substr).unwrap();
+                assert_eq!(c.clone(), dt);
+            }
+        }
+        match val.get_ref() {
+            K::Array(arr) => {
+                for v in arr.iter() {
+                    assert_span_subspan(val.span(), v.span());
+                    visit(v, s);
+                }
+            }
+            K::Table(tbl) => {
+                for (_key, v) in tbl.iter() {
+                    assert_span_subspan(val.span(), v.span());
+                    visit(v, s);
+                }
+            }
+            K::String(_) | K::Integer(_) | K::Float(_) | K::Boolean(_) | K::Datetime(_) => {}
+        }
+    }
+
+    const TEST_TOML: &str = r#"
+    # comments are supported
+    key_foo = "bazz"
+    key_baz = false
+    empty_arr = []
+    filled_arr_ints = [1, 2, 3, 4, 5]
+    key_nested_baz = { extremely_nested = "yess", other_val = true }
+    even_more_nesting = { u = 22, f = { s = { v = 32 }, w = 77 }, v = 33 }
+    [tbl]
+    hello = "world"
+    d = "hi"
+    [[arr]]
+    this_is = "something in the array"
+    [[arr]]
+    this_is = "something else in the array"
+    "#;
+    let foo: SpannedValue = toml::from_str(TEST_TOML).unwrap();
+
+    visit(&foo, TEST_TOML);
+}

--- a/test-suite/tests/spanned_value.rs
+++ b/test-suite/tests/spanned_value.rs
@@ -95,7 +95,9 @@ fn test_spanned_vals() {
                 }
             }
             K::Table(tbl) => {
-                for (_key, v) in tbl.iter() {
+                for (key, v) in tbl.iter() {
+                    assert_eq!(&s[key.start()..key.end()], key.get_ref());
+                    assert_span_subspan(val.span(), key.span());
                     assert_span_subspan(val.span(), v.span());
                     visit(v, s);
                 }
@@ -121,6 +123,9 @@ fn test_spanned_vals() {
     this_is = "something else in the array"
     "#;
     let foo: SpannedValue = toml::from_str(TEST_TOML).unwrap();
+
+    // Ensure that indexing still works
+    assert_eq!(foo.get_ref()["key_baz"].get_ref(), &K::Boolean(false));
 
     visit(&foo, TEST_TOML);
 }


### PR DESCRIPTION
Fixes #236.
Fixes #95.

Builds on #324, #328 and #333.

Limitations:

* No ability to get spans of dotted tables as well as arrays defined with `[[key]]` (inline tables as well as [] arrays do work). While we could probably special case tables/arrays that are contiguous, in the general case the toml data format allows settings where tables/arrays are spread over parts of the file. In these cases, we set both start and end of the span to 0, as this is easily detectable and no interesting value would ever have such a span. User code needs to be able to handle these cases.