### PR TITLE
Remove redundant #[doc(hidden)] attributes

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -325,8 +325,7 @@ struct Table<'a> {
     array: bool,
 }
 
-#[doc(hidden)]
-pub struct MapVisitor<'de, 'b> {
+struct MapVisitor<'de, 'b> {
     values: vec::IntoIter<TablePair<'de>>,
     next_value: Option<TablePair<'de>>,
     depth: usize,
@@ -1883,10 +1882,7 @@ impl Error {
         }
     }
 
-    /// Do not call this method, it may be removed at any time, it's just an
-    /// internal implementation detail.
-    #[doc(hidden)]
-    pub fn add_key_context(&mut self, key: &str) {
+    pub(crate) fn add_key_context(&mut self, key: &str) {
         self.inner.key.insert(0, key.to_string());
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -151,7 +151,6 @@ pub enum Error {
 }
 
 #[derive(Debug, Default, Clone)]
-#[doc(hidden)]
 /// Internal place for holding array setings
 struct ArraySettings {
     indent: usize,
@@ -167,7 +166,6 @@ impl ArraySettings {
     }
 }
 
-#[doc(hidden)]
 #[derive(Debug, Default, Clone)]
 /// String settings
 struct StringSettings {
@@ -182,7 +180,6 @@ impl StringSettings {
 }
 
 #[derive(Debug, Default, Clone)]
-#[doc(hidden)]
 /// Internal struct for holding serialization settings
 struct Settings {
     array: Option<ArraySettings>,

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,14 +1,10 @@
 use serde::{de, ser};
 use std::fmt;
 
-#[doc(hidden)]
-pub const NAME: &str = "$__toml_private_Spanned";
-#[doc(hidden)]
-pub const START: &str = "$__toml_private_start";
-#[doc(hidden)]
-pub const END: &str = "$__toml_private_end";
-#[doc(hidden)]
-pub const VALUE: &str = "$__toml_private_value";
+pub(crate) const NAME: &str = "$__toml_private_Spanned";
+pub(crate) const START: &str = "$__toml_private_start";
+pub(crate) const END: &str = "$__toml_private_end";
+pub(crate) const VALUE: &str = "$__toml_private_value";
 
 /// A spanned value, indicating the range at which it is defined in the source.
 ///


### PR DESCRIPTION
There were some `#[doc(hidden)]` attributes that weren't necessary. Other uses were replaced by `pub(crate)`.