### PR TITLE
Forbid unsafe code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version](https://img.shields.io/crates/v/toml.svg)](https://crates.io/crates/toml)
 [![Documentation](https://docs.rs/toml/badge.svg)](https://docs.rs/toml)
+[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 A [TOML][toml] decoder and encoder for Rust. This library is currently compliant
 with the v0.5.0 version of TOML. This library will also likely continue to stay

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Latest Version](https://img.shields.io/crates/v/toml.svg)](https://crates.io/crates/toml)
 [![Documentation](https://docs.rs/toml/badge.svg)](https://docs.rs/toml)
-[![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 A [TOML][toml] decoder and encoder for Rust. This library is currently compliant
 with the v0.5.0 version of TOML. This library will also likely continue to stay

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,6 @@
 #![doc(html_root_url = "https://docs.rs/toml/0.5")]
 #![deny(missing_docs)]
 #![warn(rust_2018_idioms)]
-
 // Makes rustc abort compilation if there are any unsafe blocks in the crate.
 // Presence of this annotation is picked up by tools such as cargo-geiger
 // and lets them ensure that there is indeed no unsafe code as opposed to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,8 +146,13 @@
 
 #![doc(html_root_url = "https://docs.rs/toml/0.5")]
 #![deny(missing_docs)]
-#![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
+
+// Makes rustc abort compilation if there are any unsafe blocks in the crate.
+// Presence of this annotation is picked up by tools such as cargo-geiger
+// and lets them ensure that there is indeed no unsafe code as opposed to
+// something they couldn't detect (e.g. unsafe added via macro expansion, etc).
+#![forbid(unsafe_code)]
 
 pub mod map;
 pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@
 
 #![doc(html_root_url = "https://docs.rs/toml/0.5")]
 #![deny(missing_docs)]
+#![forbid(unsafe_code)]
 #![warn(rust_2018_idioms)]
 
 pub mod map;


### PR DESCRIPTION
`#![forbid(unsafe_code)]` annotation makes rustc abort compilation if there are any unsafe blocks in the crate.

Presence of this annotation is picked up by tools such as [cargo-geiger](https://github.com/anderejd/cargo-geiger) and lets them ensure that there is indeed no unsafe code as opposed to something they couldn't detect (e.g. unsafe added via macro expansion, etc).

This also adds a badge advertising that unsafe code is forbidden. Being 100% safe is a desirable property for a crate and should be advertised. The badge currently links to Secure Code WG's community outreach repo, but I'm fine with changing the link or making the badge non-clickable.