### PR TITLE
`Spanned::get_mut` should return a mutable reference

### DIFF
--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -65,8 +65,8 @@ impl<T> Spanned<T> {
     }
 
     /// Returns a mutable reference to the contained value.
-    pub fn get_mut(&self) -> &T {
-        &self.value
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.value
     }
 }
 


### PR DESCRIPTION
See https://github.com/alexcrichton/toml-rs/issues/236#issuecomment-537994005