### PR TITLE
Support for dotted table spans

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -558,6 +558,36 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
         visitor.visit_newtype_struct(self)
     }
 
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        if name == spanned::NAME && fields == [spanned::START, spanned::END, spanned::VALUE] {
+            // TODO we can't actually emit spans here for the *entire* table/array
+            // due to the format that toml uses. Setting the start and end to 0 is
+            // *detectable* (and no reasonable span would look like that),
+            // it would be better to expose this in the API via proper
+            // ADTs like Option<T>.
+            let start = 0;
+            let end = 0;
+
+            let res = visitor.visit_map(SpannedDeserializer {
+                phantom_data: PhantomData,
+                start: Some(start),
+                value: Some(self),
+                end: Some(end),
+            });
+            return res;
+        }
+
+        self.deserialize_any(visitor)
+    }
+
     fn deserialize_enum<V>(
         self,
         _name: &'static str,
@@ -591,7 +621,7 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
 
     serde::forward_to_deserialize_any! {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
-        bytes byte_buf map struct unit identifier
+        bytes byte_buf map unit identifier
         ignored_any unit_struct tuple_struct tuple
     }
 }
@@ -850,6 +880,14 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
         bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
         bytes byte_buf map unit identifier
         ignored_any unit_struct tuple_struct tuple
+    }
+}
+
+impl<'de, 'b> de::IntoDeserializer<'de, Error> for MapVisitor<'de, 'b> {
+    type Deserializer = MapVisitor<'de, 'b>;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -572,7 +572,7 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     {
         if name == spanned::NAME
             && fields == [spanned::START, spanned::END, spanned::VALUE]
-            && self.values.peek().is_none()
+            && !(self.array && !self.values.peek().is_none())
         {
             // TODO we can't actually emit spans here for the *entire* table/array
             // due to the format that toml uses. Setting the start and end to 0 is

--- a/test-suite/tests/spanned.rs
+++ b/test-suite/tests/spanned.rs
@@ -93,17 +93,22 @@ fn test_inner_spanned_table() {
         foo: Spanned<HashMap<Spanned<String>, Spanned<String>>>,
     }
 
-    fn good(s: &str) {
+    fn good(s: &str, zero: bool) {
         let foo: Foo = toml::from_str(s).unwrap();
 
-        assert_eq!(foo.foo.start(), 0);
-        // We'd actually have to assert equality with s.len() here,
-        // but the current implementation doesn't support that,
-        // and it's not possible with toml's data format to support it
-        // in the general case as spans aren't always well-defined.
-        // So this check mainly serves as a reminder that this test should
-        // be updated *if* one day there is support for emitting the actual span.
-        assert_eq!(foo.foo.end(), 0);
+        if zero {
+            assert_eq!(foo.foo.start(), 0);
+            // We'd actually have to assert equality with s.len() here,
+            // but the current implementation doesn't support that,
+            // and it's not possible with toml's data format to support it
+            // in the general case as spans aren't always well-defined.
+            // So this check mainly serves as a reminder that this test should
+            // be updated *if* one day there is support for emitting the actual span.
+            assert_eq!(foo.foo.end(), 0);
+        } else {
+            assert_eq!(foo.foo.start(), s.find("{").unwrap());
+            assert_eq!(foo.foo.end(), s.find("}").unwrap() + 1);
+        }
         for (k, v) in foo.foo.get_ref().iter() {
             assert_eq!(&s[k.start()..k.end()], k.get_ref());
             assert_eq!(&s[(v.start() + 1)..(v.end() - 1)], v.get_ref());
@@ -118,12 +123,13 @@ fn test_inner_spanned_table() {
         c = 'd'
         e = \"f\"
     ",
+        true,
     );
 
     good(
         "
-        foo = { a = 'b', bar = 'baz', c = 'd', e = \"f\" }
-    ",
+        foo = { a = 'b', bar = 'baz', c = 'd', e = \"f\" }",
+        false,
     );
 }
 


### PR DESCRIPTION
This provides "support" for dotted table spans by setting them to 0. While special cases could get special case logic, in the general case toml allows for dotted tables without well defined spans.

In this document, the span for the `dependencies` table is for example not well-defined:

```toml
[dependencies.serde]
optional = true

[package]
name = "toml-spanned-value"

[dependencies]
toml = "0.7"
```

The package table for example does have a well-defined span and thus could be special-cased.