### PR TITLE
 Spanned: impl PartialEq, Eq, Hash, PartialOrd, Ord in terms of the value

### DIFF
--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,7 +1,8 @@
 use serde::{de, ser};
+use std::borrow::Borrow;
+use std::cmp::Ordering;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::cmp::Ordering;
 
 pub(crate) const NAME: &str = "$__toml_private_Spanned";
 pub(crate) const START: &str = "$__toml_private_start";
@@ -69,6 +70,12 @@ impl<T> Spanned<T> {
     /// Returns a mutable reference to the contained value.
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.value
+    }
+}
+
+impl Borrow<str> for Spanned<String> {
+    fn borrow(&self) -> &str {
+        &self.get_ref()
     }
 }
 

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,5 +1,7 @@
 use serde::{de, ser};
 use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::cmp::Ordering;
 
 pub(crate) const NAME: &str = "$__toml_private_Spanned";
 pub(crate) const START: &str = "$__toml_private_start";
@@ -28,7 +30,7 @@ pub(crate) const VALUE: &str = "$__toml_private_value";
 ///     assert_eq!(u.s.into_inner(), String::from("value"));
 /// }
 /// ```
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Spanned<T> {
     /// The start range.
     start: usize,
@@ -67,6 +69,32 @@ impl<T> Spanned<T> {
     /// Returns a mutable reference to the contained value.
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.value
+    }
+}
+
+impl<T: PartialEq> PartialEq for Spanned<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value.eq(&other.value)
+    }
+}
+
+impl<T: Eq> Eq for Spanned<T> {}
+
+impl<T: Hash> Hash for Spanned<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for Spanned<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.value.partial_cmp(&other.value)
+    }
+}
+
+impl<T: Ord> Ord for Spanned<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.value.cmp(&other.value)
     }
 }
 

--- a/test-suite/tests/spanned-impls.rs
+++ b/test-suite/tests/spanned-impls.rs
@@ -1,0 +1,41 @@
+use std::cmp::{Ord, Ordering, PartialOrd};
+use toml::{from_str, Spanned};
+#[macro_use]
+extern crate serde_derive;
+
+#[test]
+fn test_spans_impls() {
+    #[derive(Deserialize)]
+    struct Foo {
+        bar: Spanned<bool>,
+        baz: Spanned<String>,
+    }
+    let f: Foo = from_str(
+        "
+    bar = true
+    baz = \"yes\"
+    ",
+    )
+    .unwrap();
+    let g: Foo = from_str(
+        "
+    baz = \"yes\"
+    bar = true
+    ",
+    )
+    .unwrap();
+    assert!(f.bar.span() != g.bar.span());
+    assert!(f.baz.span() != g.baz.span());
+
+    // test that eq still holds
+    assert_eq!(f.bar, g.bar);
+    assert_eq!(f.baz, g.baz);
+
+    // test that Ord returns equal order
+    assert_eq!(f.bar.cmp(&g.bar), Ordering::Equal);
+    assert_eq!(f.baz.cmp(&g.baz), Ordering::Equal);
+
+    // test that PartialOrd returns equal order
+    assert_eq!(f.bar.partial_cmp(&g.bar), Some(Ordering::Equal));
+    assert_eq!(f.baz.partial_cmp(&g.baz), Some(Ordering::Equal));
+}


### PR DESCRIPTION
This is because we want to be able to index into HashMap<Spanned<String>, T>
with a dummy span and get results where only the content has to match.

For more info, see #327 and #341