### PR TITLE
Remove outdated Travis CI badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,6 @@ edition = "2018"
 [workspace]
 members = ['test-suite']
 
-[badges]
-travis-ci = { repository = "alexcrichton/toml-rs" }
-
 [dependencies]
 serde = "1.0.97"
 linked-hash-map = { version = "0.5", optional = true }


### PR DESCRIPTION
since this repository is no longer using Travis CI for development.