### PR TITLE
Decrease deserialization complexity from quadratic to linear

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -323,6 +323,16 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
     }
 }
 
+// Builds a datastructure that allows for efficient sublinear lookups.
+// The returned HashMap contains a mapping from table header (like [a.b.c])
+// to list of tables with that precise name. The tables are being identified
+// by their index in the passed slice. We use a list as the implementation
+// uses this data structure for arrays as well as tables,
+// so if any top level [[name]] array contains multiple entries,
+// there are multiple entires in the list.
+// The lookup is performed in the `SeqAccess` implementation of `MapVisitor`.
+// The lists are ordered, which we exploit in the search code by using
+// bisection.
 fn build_table_indices<'de>(tables: &[Table<'de>]) -> HashMap<Vec<Cow<'de, str>>, Vec<usize>> {
     let mut res = HashMap::new();
     for (i, table) in tables.iter().enumerate() {
@@ -332,6 +342,21 @@ fn build_table_indices<'de>(tables: &[Table<'de>]) -> HashMap<Vec<Cow<'de, str>>
     res
 }
 
+// Builds a datastructure that allows for efficient sublinear lookups.
+// The returned HashMap contains a mapping from table header (like [a.b.c])
+// to list of tables whose name at least starts with the specified
+// name. So searching for [a.b] would give both [a.b.c.d] as well as [a.b.e].
+// The tables are being identified by their index in the passed slice.
+//
+// A list is used for two reasons: First, the implementation also
+// stores arrays in the same data structure and any top level array
+// of size 2 or greater creates multiple entries in the list with the
+// same shared name. Second, there can be multiple tables sharing
+// the same prefix.
+//
+// The lookup is performed in the `MapAccess` implementation of `MapVisitor`.
+// The lists are ordered, which we exploit in the search code by using
+// bisection.
 fn build_table_pindices<'de>(tables: &[Table<'de>]) -> HashMap<Vec<Cow<'de, str>>, Vec<usize>> {
     let mut res = HashMap::new();
     for (i, table) in tables.iter().enumerate() {

--- a/src/de.rs
+++ b/src/de.rs
@@ -400,9 +400,7 @@ impl<'de, 'b> de::MapAccess<'de> for MapVisitor<'de, 'b> {
                 self.table_pindices
                     .get(&prefix_stripped)
                     .and_then(|entries| {
-                        let start = entries
-                            .binary_search(&self.cur)
-                            .unwrap_or_else(std::convert::identity);
+                        let start = entries.binary_search(&self.cur).unwrap_or_else(|v| v);
                         if start == entries.len() || entries[start] < self.cur {
                             return None;
                         }
@@ -541,9 +539,7 @@ impl<'de, 'b> de::SeqAccess<'de> for MapVisitor<'de, 'b> {
             .table_indices
             .get(&header_stripped)
             .and_then(|entries| {
-                let start = entries
-                    .binary_search(&start_idx)
-                    .unwrap_or_else(std::convert::identity);
+                let start = entries.binary_search(&start_idx).unwrap_or_else(|v| v);
                 if start == entries.len() || entries[start] < start_idx {
                     return None;
                 }

--- a/test-suite/tests/linear.rs
+++ b/test-suite/tests/linear.rs
@@ -1,0 +1,37 @@
+use std::time::{Duration, Instant};
+use toml::Value;
+
+const TOLERANCE: f64 = 2.0;
+
+fn measure_time(entries: usize, f: impl Fn(usize) -> String) -> Duration {
+    let start = Instant::now();
+    let mut s = String::new();
+    for i in 0..entries {
+        s += &f(i);
+        s += "entry = 42\n"
+    }
+    s.parse::<Value>().unwrap();
+    Instant::now() - start
+}
+
+#[test]
+fn linear_increase_map() {
+    let time_1 = measure_time(100, |i| format!("[header_no_{}]\n", i));
+    let time_4 = measure_time(400, |i| format!("[header_no_{}]\n", i));
+    dbg!(time_1, time_4);
+    // Now ensure that the deserialization time has increased linearly
+    // (within a tolerance interval) instead of, say, quadratically
+    assert!(time_4 > time_1.mul_f64(4.0 - TOLERANCE));
+    assert!(time_4 < time_1.mul_f64(4.0 + TOLERANCE));
+}
+
+#[test]
+fn linear_increase_array() {
+    let time_1 = measure_time(100, |i| format!("[[header_no_{}]]\n", i));
+    let time_4 = measure_time(400, |i| format!("[[header_no_{}]]\n", i));
+    dbg!(time_1, time_4);
+    // Now ensure that the deserialization time has increased linearly
+    // (within a tolerance interval) instead of, say, quadratically
+    assert!(time_4 > time_1.mul_f64(4.0 - TOLERANCE));
+    assert!(time_4 < time_1.mul_f64(4.0 + TOLERANCE));
+}


### PR DESCRIPTION
Fixes #342.

In particular, see my comment https://github.com/alexcrichton/toml-rs/issues/342#issuecomment-546190394

Values that I recorded on my machine for running the code `measure_time(n, |i| format!("[header_no_{}]\n", i))` function for varying `n`:

| benchmark  | optimizations | before this PR | after this PR |
|------------|---------------|----------------|---------------|
|          1k|             no|           170ms|           48ms|
|         10k|             no|         14 191ms|          483ms|
|        100k|             no|             n/a|         5 077ms|
|          1k|            yes|             5ms|            4ms|
|         10k|            yes|           311ms|           39ms|
|        100k|            yes|         63 850ms|          364ms|

You can nicely see how before this PR, a 10x increase in data meant a 100x increase in time spent, while after the PR it only means a 10x increase.