### PR TITLE
iter_copied rustc 1.35 compatibility fix #353

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -432,8 +432,7 @@ impl<'de, 'b> de::MapAccess<'de> for MapVisitor<'de, 'b> {
                         }
                         entries[start..]
                             .iter()
-                            .copied()
-                            .filter(|i| *i < self.max)
+                            .filter_map(|i| if *i < self.max { Some(*i) } else { None })
                             .map(|i| (i, &self.tables[i]))
                             .find(|(_, table)| table.values.is_some())
                             .map(|p| p.0)
@@ -572,8 +571,7 @@ impl<'de, 'b> de::SeqAccess<'de> for MapVisitor<'de, 'b> {
                 }
                 entries[start..]
                     .iter()
-                    .copied()
-                    .filter(|i| *i < self.max)
+                    .filter_map(|i| if *i < self.max { Some(*i) } else { None })
                     .map(|i| (i, &self.tables[i]))
                     .find(|(_, table)| table.array)
                     .map(|p| p.0)


### PR DESCRIPTION
Replaced copied with filter_map for rustc 1.35 compatibility. This should fix projects like mentioned by @dvogt23 in issue #353 which are still using rustc 1.35 might automatically pull 0.5.4 since it is patch semver.

```
% cargo +1.35.0 test
   Compiling toml v0.5.4 (/Users/max/src/opensource/toml-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 4.37s
     Running target/debug/deps/toml-bd94711eee332035

running 6 tests
test tokens::tests::bad_comment ... ok
test tokens::tests::bare_cr_bad ... ok
test tokens::tests::all ... ok
test tokens::tests::keylike ... ok
test tokens::tests::basic_strings ... ok
test tokens::tests::literal_strings ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/enum_external_deserialize-e6d4b6530bf5385b

running 16 tests
test enum_array::from_dotted_table ... ignored
test enum_newtype::from_dotted_table ... ignored
test enum_struct::from_dotted_table ... ok
test enum_newtype::from_inline_table ... ok
test enum_struct::from_inline_table ... ok
test enum_array::from_inline_tables ... ok
test enum_tuple::from_dotted_table ... ok
test enum_struct::from_nested_dotted_table ... ok
test enum_unit::from_dotted_table ... ok
test enum_unit::from_str ... ok
test enum_unit::from_inline_table ... ok
test extra_field_returns_expected_empty_table_error ... ok
test enum_tuple::from_inline_table ... ok
test invalid_variant_returns_error_with_good_message_inline_table ... ok
test invalid_variant_returns_error_with_good_message_string ... ok
test extra_field_returns_expected_empty_table_error_struct_variant ... ok

test result: ok. 14 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out

   Doc-tests toml

running 10 tests
test src/lib.rs -  (line 26) ... ignored
test src/lib.rs -  (line 46) ... ok
test src/lib.rs -  (line 113) ... ok
test src/macros.rs - toml (line 9) ... ok
test src/ser.rs - ser (line 14) ... ok
test src/de.rs - de::from_str (line 50) ... ok
test src/ser.rs - ser::tables_last (line 1579) ... ok
test src/lib.rs -  (line 79) ... ok
test src/ser.rs - ser::to_string (line 57) ... ok
test src/spanned.rs - spanned::Spanned (line 14) ... ok

test result: ok. 9 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```