### PR TITLE
Fix parsing enum variants in dotted keys

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -915,7 +915,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
     {
         match self.value.e {
             E::String(val) => visitor.visit_enum(val.into_deserializer()),
-            E::InlineTable(values) => {
+            E::InlineTable(values) | E::DottedTable(values) => {
                 if values.len() != 1 {
                     Err(Error::from_kind(
                         Some(self.value.start),
@@ -938,7 +938,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer<'de> {
             e => Err(Error::from_kind(
                 Some(self.value.start),
                 ErrorKind::Wanted {
-                    expected: "string or inline table",
+                    expected: "string or table",
                     found: e.type_name(),
                 },
             )),

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -16,8 +16,8 @@ enum TheEnum {
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
-struct Val {
-    val: TheEnum,
+struct Val<T> {
+    val: T,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -84,6 +84,18 @@ mod enum_unit {
     #[test]
     fn from_dotted_table() {
         assert_eq!(TheEnum::Plain, toml::from_str("[Plain]\n").unwrap());
+    }
+
+    #[test]
+    fn from_dotted_key() {
+        assert_eq!(
+            Val {
+                val: Val {
+                    val: TheEnum::Plain
+                }
+            },
+            toml::from_str("[val]\nval.Plain = {}\n").unwrap()
+        );
     }
 }
 


### PR DESCRIPTION
I tried looking into why DottedTable was not allowed in this match statement, but it seems it was only in order to be conservative. The or-pattern was removed [here](https://github.com/alexcrichton/toml-rs/commit/fcc4a58617ea27a061f445b576e3fafc91ad6998#diff-bcad83e135b6617746a5472d41ac63e9L604-R582), but the resulting enum syntax is pretty nice. Other tables extending the object are handled outside of this struct, because deserialize_any in this deserializer already relies on this.

Fixes #350