### PR TITLE
Expose part of de::ErrorInner publicly

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -98,9 +98,9 @@ struct ErrorInner {
     key: Vec<String>,
 }
 
-/// Errors that can occur when deserializing a type.
+/// Kinds of errors that can occur when deserializing a type.
 #[derive(Debug, PartialEq, Eq, Clone)]
-enum ErrorKind {
+pub enum ErrorKind {
     /// EOF was reached when looking for a value
     UnexpectedEof,
 
@@ -2023,6 +2023,11 @@ impl Error {
     /// Get the keys associated with this error
     pub fn key(&self) -> &[String] {
         &self.inner.key
+    }
+
+    /// Get the error kind of this error
+    pub fn kind(&self) -> &ErrorKind {
+        &self.inner.kind
     }
 
     fn from_kind(at: Option<usize>, kind: ErrorKind) -> Error {

--- a/src/de.rs
+++ b/src/de.rs
@@ -94,7 +94,6 @@ struct ErrorInner {
     line: Option<usize>,
     col: usize,
     at: Option<usize>,
-    message: String,
     key: Vec<String>,
 }
 
@@ -160,7 +159,7 @@ pub enum ErrorKind {
 
     /// A custom error which could be generated when deserializing a particular
     /// type.
-    Custom,
+    Custom(String),
 
     /// A tuple with a certain number of elements was expected but something
     /// else was found.
@@ -2015,11 +2014,6 @@ impl Error {
         self.inner.line.map(|line| (line, self.inner.col))
     }
 
-    /// Get the message associated with this error
-    pub fn message(&self) -> &str {
-        &self.inner.message
-    }
-
     /// Get the keys associated with this error
     pub fn key(&self) -> &[String] {
         &self.inner.key
@@ -2037,7 +2031,6 @@ impl Error {
                 line: None,
                 col: 0,
                 at,
-                message: String::new(),
                 key: Vec::new(),
             }),
         }
@@ -2046,11 +2039,10 @@ impl Error {
     fn custom(at: Option<usize>, s: String) -> Error {
         Error {
             inner: Box::new(ErrorInner {
-                kind: ErrorKind::Custom,
+                kind: ErrorKind::Custom(s),
                 line: None,
                 col: 0,
                 at,
-                message: s,
                 key: Vec::new(),
             }),
         }
@@ -2128,7 +2120,7 @@ impl fmt::Display for Error {
             ErrorKind::RedefineAsArray => "table redefined as array".fmt(f)?,
             ErrorKind::EmptyTableKey => "empty table key found".fmt(f)?,
             ErrorKind::MultilineStringKey => "multiline strings are not allowed for key".fmt(f)?,
-            ErrorKind::Custom => self.inner.message.fmt(f)?,
+            ErrorKind::Custom(ref message) => message.fmt(f)?,
             ErrorKind::ExpectedTuple(l) => write!(f, "expected table with length {}", l)?,
             ErrorKind::ExpectedTupleIndex {
                 expected,

--- a/src/de.rs
+++ b/src/de.rs
@@ -2015,6 +2015,16 @@ impl Error {
         self.inner.line.map(|line| (line, self.inner.col))
     }
 
+    /// Get the message associated with this error
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+
+    /// Get the keys associated with this error
+    pub fn key(&self) -> &[String] {
+        &self.inner.key
+    }
+
     fn from_kind(at: Option<usize>, kind: ErrorKind) -> Error {
         Error {
             inner: Box::new(ErrorInner {

--- a/src/de.rs
+++ b/src/de.rs
@@ -2015,8 +2015,12 @@ impl Error {
     }
 
     /// Get the keys associated with this error
-    pub fn key(&self) -> &[String] {
-        &self.inner.key
+    pub fn keys(&self) -> Option<&[String]> {
+        if self.inner.key.is_empty() {
+            None
+        } else {
+            Some(&self.inner.key)
+        }
     }
 
     /// Get the error kind of this error


### PR DESCRIPTION
See #360. 

The second commit exposes `de::ErrorKind` publicly, if this is not desired I can remove it. It should be fine to expose since it is already marked as `non_exhaustive`, using `#[doc(hidden)]`.