### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -422,8 +422,4 @@ impl fmt::Display for DatetimeParseError {
     }
 }
 
-impl error::Error for DatetimeParseError {
-    fn description(&self) -> &str {
-        "failed to parse datetime"
-    }
-}
+impl error::Error for DatetimeParseError {}

--- a/src/de.rs
+++ b/src/de.rs
@@ -2153,35 +2153,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match self.inner.kind {
-            ErrorKind::UnexpectedEof => "unexpected eof encountered",
-            ErrorKind::InvalidCharInString(_) => "invalid char in string",
-            ErrorKind::InvalidEscape(_) => "invalid escape in string",
-            ErrorKind::InvalidHexEscape(_) => "invalid hex escape in string",
-            ErrorKind::InvalidEscapeValue(_) => "invalid escape value in string",
-            ErrorKind::NewlineInString => "newline in string found",
-            ErrorKind::Unexpected(_) => "unexpected or invalid character",
-            ErrorKind::UnterminatedString => "unterminated string",
-            ErrorKind::NewlineInTableKey => "found newline in table key",
-            ErrorKind::Wanted { .. } => "expected a token but found another",
-            ErrorKind::NumberInvalid => "invalid number",
-            ErrorKind::DateInvalid => "invalid date",
-            ErrorKind::DuplicateTable(_) => "duplicate table",
-            ErrorKind::RedefineAsArray => "table redefined as array",
-            ErrorKind::EmptyTableKey => "empty table key found",
-            ErrorKind::MultilineStringKey => "invalid multiline string for key",
-            ErrorKind::Custom => "a custom error",
-            ErrorKind::ExpectedTuple(_) => "expected table length",
-            ErrorKind::ExpectedTupleIndex { .. } => "expected table key",
-            ErrorKind::ExpectedEmptyTable => "expected empty table",
-            ErrorKind::DottedKeyInvalidType => "dotted key invalid type",
-            ErrorKind::UnexpectedKeys { .. } => "unexpected keys in table",
-            ErrorKind::__Nonexhaustive => panic!(),
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1542,22 +1542,7 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::UnsupportedType => "unsupported Rust type",
-            Error::KeyNotString => "map key was not a string",
-            Error::ValueAfterTable => "values must be emitted before tables",
-            Error::DateInvalid => "a serialized date was invalid",
-            Error::NumberInvalid => "a serialized number was invalid",
-            Error::UnsupportedNone => "unsupported None value",
-            Error::Custom(_) => "custom error",
-            Error::KeyNewline => unreachable!(),
-            Error::ArrayMixedType => unreachable!(),
-            Error::__Nonexhaustive => panic!(),
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes all implementations of `description` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919