### PR TITLE
Fix a couple errors in DateStrEmitter

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1262,11 +1262,11 @@ impl<'a, 'b> ser::Serializer for DateStrEmitter<'a, 'b> {
     where
         T: ser::Serialize,
     {
-        Err(Error::KeyNotString)
+        Err(Error::DateInvalid)
     }
 
     fn serialize_unit(self) -> Result<(), Self::Error> {
-        Err(Error::KeyNotString)
+        Err(Error::DateInvalid)
     }
 
     fn serialize_unit_struct(self, _name: &'static str) -> Result<(), Self::Error> {


### PR DESCRIPTION
Before this change, there were a couple cases in `DateStrEmitter` report `KeyNotString` errors instead of `DateInvalid`.