### PR TITLE
Make UnsupportedType error more informative

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -796,11 +796,19 @@ impl ser::Serializer for Serializer {
     }
 
     fn serialize_unit(self) -> Result<Value, crate::ser::Error> {
-        Err(crate::ser::Error::UnsupportedType)
+        Err(crate::ser::Error::UnsupportedType {
+            name: None,
+            variant: None,
+            variety: String::from("unit"),
+        })
     }
 
-    fn serialize_unit_struct(self, _name: &'static str) -> Result<Value, crate::ser::Error> {
-        Err(crate::ser::Error::UnsupportedType)
+    fn serialize_unit_struct(self, name: &'static str) -> Result<Value, crate::ser::Error> {
+        Err(crate::ser::Error::UnsupportedType {
+            name: Some(String::from(name)),
+            variant: None,
+            variety: String::from("unit struct"),
+        })
     }
 
     fn serialize_unit_variant(
@@ -825,15 +833,19 @@ impl ser::Serializer for Serializer {
 
     fn serialize_newtype_variant<T: ?Sized>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
         _value: &T,
     ) -> Result<Value, crate::ser::Error>
     where
         T: ser::Serialize,
     {
-        Err(crate::ser::Error::UnsupportedType)
+        Err(crate::ser::Error::UnsupportedType {
+            name: Some(String::from(name)),
+            variant: Some(String::from(variant)),
+            variety: String::from("newtype variant"),
+        })
     }
 
     fn serialize_none(self) -> Result<Value, crate::ser::Error> {
@@ -892,12 +904,16 @@ impl ser::Serializer for Serializer {
 
     fn serialize_struct_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, crate::ser::Error> {
-        Err(crate::ser::Error::UnsupportedType)
+        Err(crate::ser::Error::UnsupportedType {
+            name: Some(String::from(name)),
+            variant: Some(String::from(variant)),
+            variety: String::from("newtype variant"),
+        })
     }
 }
 


### PR DESCRIPTION
`UnsupportedType` with no further info is not very helpful when trying to serialize a complex structure.  This adds more information so that the source of the problem is clearer to the developer.

I realize that this is a breaking change.  An alternative I considered was adding a variant to the enum, but I think this is better.  Cases where users are explicitly matching on this probably ought to be updated - hopefully there are few in the wild.