### PR TITLE
Implement writers from to serde_json

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,9 @@ mod datetime;
 
 pub mod ser;
 #[doc(inline)]
-pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer};
+pub use crate::ser::{
+    to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
+};
 pub mod de;
 #[doc(inline)]
 pub use crate::de::{from_slice, from_str, Deserializer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,10 @@ pub use crate::value::Value;
 mod datetime;
 
 pub mod ser;
-#[doc(no_inline)]
-pub use crate::ser::{to_string, to_string_pretty, to_vec, Serializer};
+#[doc(inline)]
+pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer};
 pub mod de;
-#[doc(no_inline)]
+#[doc(inline)]
 pub use crate::de::{from_slice, from_str, Deserializer};
 mod tokens;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -282,7 +282,10 @@ pub enum SerializeTable<'a, 'b, W> {
     },
 }
 
-impl<'a, W> Serializer<'a, W> where W: Write {
+impl<'a, W> Serializer<'a, W>
+where
+    W: Write,
+{
     /// Creates a new serializer which will emit TOML into the buffer provided.
     ///
     /// The serializer can then be used to serialize a type after which the data
@@ -464,7 +467,9 @@ impl<'a, W> Serializer<'a, W> where W: Write {
 
     #[inline(always)]
     fn push_str(&mut self, value: &str) -> Result<(), Error> {
-        self.dst.write_all(value.as_bytes()).map_err(|e| Error::WriteError(e))
+        self.dst
+            .write_all(value.as_bytes())
+            .map_err(|e| Error::WriteError(e))
     }
 
     fn display<T: fmt::Display>(&mut self, t: T, type_: ArrayState) -> Result<(), Error> {
@@ -694,7 +699,7 @@ impl<'a, W> Serializer<'a, W> where W: Write {
                         c if c <= '\u{1f}' || c == '\u{7f}' => {
                             write!(self.dst, "\\u{:04X}", ch as u32).map_err(Error::WriteError)?;
                         }
-                        ch => write!(self.dst, "{}", ch).map_err(Error::WriteError)?
+                        ch => write!(self.dst, "{}", ch).map_err(Error::WriteError)?,
                     }
                 }
                 match ty {
@@ -813,7 +818,10 @@ macro_rules! serialize_float {
     }};
 }
 
-impl<'a, 'b, W> ser::Serializer for &'b mut Serializer<'a, W> where W: Write {
+impl<'a, 'b, W> ser::Serializer for &'b mut Serializer<'a, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
     type SerializeSeq = SerializeSeq<'a, 'b, W>;
@@ -1011,7 +1019,10 @@ impl<'a, 'b, W> ser::Serializer for &'b mut Serializer<'a, W> where W: Write {
     }
 }
 
-impl<'a, 'b, W> ser::SerializeSeq for SerializeSeq<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::SerializeSeq for SerializeSeq<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -1060,7 +1071,10 @@ impl<'a, 'b, W> ser::SerializeSeq for SerializeSeq<'a, 'b, W> where W: Write {
     }
 }
 
-impl<'a, 'b, W> ser::SerializeTuple for SerializeSeq<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::SerializeTuple for SerializeSeq<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -1076,7 +1090,10 @@ impl<'a, 'b, W> ser::SerializeTuple for SerializeSeq<'a, 'b, W> where W: Write {
     }
 }
 
-impl<'a, 'b, W> ser::SerializeTupleVariant for SerializeSeq<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::SerializeTupleVariant for SerializeSeq<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -1092,7 +1109,10 @@ impl<'a, 'b, W> ser::SerializeTupleVariant for SerializeSeq<'a, 'b, W> where W: 
     }
 }
 
-impl<'a, 'b, W> ser::SerializeTupleStruct for SerializeSeq<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::SerializeTupleStruct for SerializeSeq<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -1108,7 +1128,10 @@ impl<'a, 'b, W> ser::SerializeTupleStruct for SerializeSeq<'a, 'b, W> where W: W
     }
 }
 
-impl<'a, 'b, W> ser::SerializeMap for SerializeTable<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::SerializeMap for SerializeTable<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -1173,7 +1196,10 @@ impl<'a, 'b, W> ser::SerializeMap for SerializeTable<'a, 'b, W> where W: Write {
     }
 }
 
-impl<'a, 'b, W> ser::SerializeStruct for SerializeTable<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::SerializeStruct for SerializeTable<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
 
@@ -1231,7 +1257,10 @@ impl<'a, 'b, W> ser::SerializeStruct for SerializeTable<'a, 'b, W> where W: Writ
 
 struct DateStrEmitter<'a, 'b, W>(&'b mut Serializer<'a, W>);
 
-impl<'a, 'b, W> ser::Serializer for DateStrEmitter<'a, 'b, W> where W: Write {
+impl<'a, 'b, W> ser::Serializer for DateStrEmitter<'a, 'b, W>
+where
+    W: Write,
+{
     type Ok = ();
     type Error = Error;
     type SerializeSeq = ser::Impossible<(), Error>;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -573,8 +573,8 @@ where
     fn emit_str(&mut self, value: &str, is_key: bool) -> Result<(), Error> {
         #[derive(PartialEq)]
         enum Type {
-            NewlineTripple,
-            OnelineTripple,
+            NewlineTriple,
+            OnelineTriple,
             OnelineSingle,
         }
 
@@ -617,7 +617,7 @@ where
                     }
                     match ch {
                         '\t' => {}
-                        '\n' => ty = Type::NewlineTripple,
+                        '\n' => ty = Type::NewlineTriple,
                         // Escape codes are needed if any ascii control
                         // characters are present, including \b \f \r.
                         c if c <= '\u{1f}' || c == '\u{7f}' => can_be_pretty = false,
@@ -628,7 +628,7 @@ where
                     // the string cannot be represented as pretty,
                     // still check if it should be multiline
                     if ch == '\n' {
-                        ty = Type::NewlineTripple;
+                        ty = Type::NewlineTriple;
                     }
                 }
             }
@@ -637,7 +637,7 @@ where
                 can_be_pretty = false;
             }
             if !can_be_pretty {
-                debug_assert!(ty != Type::OnelineTripple);
+                debug_assert!(ty != Type::OnelineTriple);
                 return Repr::Std(ty);
             }
             if found_singles > max_found_singles {
@@ -646,7 +646,7 @@ where
             debug_assert!(max_found_singles < 3);
             if ty == Type::OnelineSingle && max_found_singles >= 1 {
                 // no newlines, but must use ''' because it has ' in it
-                ty = Type::OnelineTripple;
+                ty = Type::OnelineTriple;
             }
             Repr::Literal(out, ty)
         }
@@ -665,8 +665,8 @@ where
             Repr::Literal(literal, ty) => {
                 // A pretty string
                 match ty {
-                    Type::NewlineTripple => self.push_str("'''\n")?,
-                    Type::OnelineTripple => self.push_str("'''")?,
+                    Type::NewlineTriple => self.push_str("'''\n")?,
+                    Type::OnelineTriple => self.push_str("'''")?,
                     Type::OnelineSingle => self.push_str("\'")?,
                 }
                 self.push_str(&literal)?;
@@ -677,18 +677,18 @@ where
             }
             Repr::Std(ty) => {
                 match ty {
-                    Type::NewlineTripple => self.push_str("\"\"\"\n")?,
-                    // note: OnelineTripple can happen if do_pretty wants to do
+                    Type::NewlineTriple => self.push_str("\"\"\"\n")?,
+                    // note: OnelineTriple can happen if do_pretty wants to do
                     // '''it's one line'''
                     // but settings.string.literal == false
-                    Type::OnelineSingle | Type::OnelineTripple => self.push_str("\"")?,
+                    Type::OnelineSingle | Type::OnelineTriple => self.push_str("\"")?,
                 }
                 for ch in value.chars() {
                     match ch {
                         '\u{8}' => self.push_str("\\b")?,
                         '\u{9}' => self.push_str("\\t")?,
                         '\u{a}' => match ty {
-                            Type::NewlineTripple => self.push_str("\n")?,
+                            Type::NewlineTriple => self.push_str("\n")?,
                             Type::OnelineSingle => self.push_str("\\n")?,
                             _ => unreachable!(),
                         },
@@ -703,8 +703,8 @@ where
                     }
                 }
                 match ty {
-                    Type::NewlineTripple => self.push_str("\"\"\"")?,
-                    Type::OnelineSingle | Type::OnelineTripple => self.push_str("\"")?,
+                    Type::NewlineTriple => self.push_str("\"\"\"")?,
+                    Type::OnelineSingle | Type::OnelineTriple => self.push_str("\"")?,
                 }
             }
         }


### PR DESCRIPTION
Resolves #216. Alternative to #257.

The interface for the writers is precisely the same as in `serde_json` except using the `toml` Error type. As this codebase is set to not allow `unsafe`, I changed the unsafe utf8 conversions to their lossy equivalent, though we guarantee UTF-8 so this should be truly equivalent and lossless.

Didn't do readers yet as they're a bit more involved. Also fixed a couple of typos while I was there.

