### PR TITLE
Added no_std support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
+    - run: cargo build --no-default-features
     - run: cargo test
     - run: cargo test --features preserve_order
     - run: cargo test --manifest-path test-suite/Cargo.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,15 +20,17 @@ edition = "2018"
 members = ['test-suite']
 
 [dependencies]
-serde = "1.0.97"
+serde = { version = "1.0.97", default-features = false, features = ["alloc"] }
 indexmap = { version = "1.0", optional = true }
+hashbrown = { version = "0.7.2" }
 
 [dev-dependencies]
 serde_derive = "1.0"
-serde_json = "1.0"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [features]
-default = []
+default = ["std"]
+std = ["serde/std", "serde_json/std"]
 
 # Use indexmap rather than BTreeMap as the map type of toml::Value.
 # This allows data to be read into a Value and written back to a TOML string

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["std"]
-std = ["serde/std", "serde_json/std"]
+std = ["serde/std"]
 
 # Use indexmap rather than BTreeMap as the map type of toml::Value.
 # This allows data to be read into a Value and written back to a TOML string

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,6 +1,13 @@
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt;
-use std::str::{self, FromStr};
+
+use core::fmt;
+use core::str::{self, FromStr};
+
+#[cfg(not(feature = "std"))]
+use alloc::format;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 use serde::{de, ser};
 
@@ -422,4 +429,5 @@ impl fmt::Display for DatetimeParseError {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for DatetimeParseError {}

--- a/src/de.rs
+++ b/src/de.rs
@@ -4,15 +4,26 @@
 //! into Rust structures. Note that some top-level functions here are also
 //! provided at the top of the crate.
 
-use std::borrow::Cow;
-use std::collections::HashMap;
+use alloc::borrow::Cow;
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
 use std::error;
-use std::f64;
-use std::fmt;
-use std::iter;
-use std::marker::PhantomData;
-use std::str;
-use std::vec;
+use core::f64;
+use core::fmt;
+use core::iter;
+use core::marker::PhantomData;
+use core::str;
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
 
 use serde::de;
 use serde::de::value::BorrowedStrDeserializer;
@@ -2041,7 +2052,7 @@ impl Error {
         }
     }
 
-    pub(crate) fn add_key_context(&mut self, key: &str) {
+    pub(crate) fn add_key_context(&mut self, key: &str) {    
         self.inner.key.insert(0, key.to_string());
     }
 
@@ -2068,6 +2079,7 @@ impl Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::convert::From<Error> for std::io::Error {
     fn from(e: Error) -> Self {
         std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
@@ -2153,10 +2165,11 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {}
 
 impl de::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Error {
+    fn custom<T: fmt::Display>(msg: T) -> Error {    
         Error::custom(None, msg.to_string())
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,25 +5,25 @@
 //! provided at the top of the crate.
 
 use alloc::borrow::Cow;
-use hashbrown::HashMap;
-#[cfg(feature = "std")]
-use std::error;
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use core::f64;
 use core::fmt;
 use core::iter;
 use core::marker::PhantomData;
 use core::str;
-use alloc::vec;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::string::ToString;
-#[cfg(not(feature = "std"))]
-use alloc::borrow::ToOwned;
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
+use std::error;
 
 use serde::de;
 use serde::de::value::BorrowedStrDeserializer;
@@ -2052,7 +2052,7 @@ impl Error {
         }
     }
 
-    pub(crate) fn add_key_context(&mut self, key: &str) {    
+    pub(crate) fn add_key_context(&mut self, key: &str) {
         self.inner.key.insert(0, key.to_string());
     }
 
@@ -2169,7 +2169,7 @@ impl fmt::Display for Error {
 impl error::Error for Error {}
 
 impl de::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Error {    
+    fn custom<T: fmt::Display>(msg: T) -> Error {
         Error::custom(None, msg.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,10 @@
 // and lets them ensure that there is indeed no unsafe code as opposed to
 // something they couldn't detect (e.g. unsafe added via macro expansion, etc).
 #![forbid(unsafe_code)]
+// When not testing and when the 'std' feature is not enabled, use no_std.
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+
+extern crate alloc;
 
 pub mod map;
 pub mod value;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -428,6 +428,9 @@ pub fn push_toml(root: &mut Value, path: &[&str]) {
 }
 
 fn traverse<'a>(root: &'a mut Value, path: &[&str]) -> &'a mut Value {
+    #[cfg(not(feature = "std"))]
+    use alloc::borrow::ToOwned;
+
     let mut cur = root;
     for &key in path {
         // Lexical lifetimes :D

--- a/src/map.rs
+++ b/src/map.rs
@@ -16,14 +16,17 @@
 
 use crate::value::Value;
 use serde::{de, ser};
-use std::borrow::Borrow;
-use std::fmt::{self, Debug};
-use std::hash::Hash;
-use std::iter::FromIterator;
-use std::ops;
+use core::borrow::Borrow;
+use core::fmt::{self, Debug};
+use core::hash::Hash;
+use core::iter::FromIterator;
+use core::ops;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 #[cfg(not(feature = "preserve_order"))]
-use std::collections::{btree_map, BTreeMap};
+use alloc::collections::{btree_map, BTreeMap};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -147,7 +150,7 @@ impl Map<String, Value> {
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
         #[cfg(not(feature = "preserve_order"))]
-        use std::collections::btree_map::Entry as EntryImpl;
+        use alloc::collections::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant }),

--- a/src/map.rs
+++ b/src/map.rs
@@ -15,12 +15,12 @@
 //! [`LinkedHashMap`]: https://docs.rs/linked-hash-map/*/linked_hash_map/struct.LinkedHashMap.html
 
 use crate::value::Value;
-use serde::{de, ser};
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::hash::Hash;
 use core::iter::FromIterator;
 use core::ops;
+use serde::{de, ser};
 
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
@@ -147,10 +147,10 @@ impl Map<String, Value> {
     where
         S: Into<String>,
     {
-        #[cfg(feature = "preserve_order")]
-        use indexmap::map::Entry as EntryImpl;
         #[cfg(not(feature = "preserve_order"))]
         use alloc::collections::btree_map::Entry as EntryImpl;
+        #[cfg(feature = "preserve_order")]
+        use indexmap::map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant }),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -25,18 +25,18 @@
 //! # fn main() {}
 //! ```
 
-use core::cell::Cell;
-#[cfg(feature = "std")]
-use std::error;
-use core::fmt::{self, Write};
-use core::marker;
 use alloc::rc::Rc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::string::ToString;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+use core::cell::Cell;
+use core::fmt::{self, Write};
+use core::marker;
+#[cfg(feature = "std")]
+use std::error;
 
 use crate::datetime;
 use serde::ser;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -25,11 +25,18 @@
 //! # fn main() {}
 //! ```
 
-use std::cell::Cell;
+use core::cell::Cell;
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt::{self, Write};
-use std::marker;
-use std::rc::Rc;
+use core::fmt::{self, Write};
+use core::marker;
+use alloc::rc::Rc;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
 
 use crate::datetime;
 use serde::ser;
@@ -1543,6 +1550,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {}
 
 impl ser::Error for Error {

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,8 +1,11 @@
 use serde::{de, ser};
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash::{Hash, Hasher};
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 pub(crate) const NAME: &str = "$__toml_private_Spanned";
 pub(crate) const START: &str = "$__toml_private_start";
@@ -113,7 +116,7 @@ where
     where
         D: de::Deserializer<'de>,
     {
-        struct SpannedVisitor<T>(::std::marker::PhantomData<T>);
+        struct SpannedVisitor<T>(::core::marker::PhantomData<T>);
 
         impl<'de, T> de::Visitor<'de> for SpannedVisitor<T>
         where
@@ -151,7 +154,7 @@ where
             }
         }
 
-        let visitor = SpannedVisitor(::std::marker::PhantomData);
+        let visitor = SpannedVisitor(::core::marker::PhantomData);
 
         static FIELDS: [&str; 3] = [START, END, VALUE];
         deserializer.deserialize_struct(NAME, &FIELDS, visitor)

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,8 +1,8 @@
-use serde::{de, ser};
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use serde::{de, ser};
 
 #[cfg(not(feature = "std"))]
 use alloc::string::String;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,8 +1,8 @@
-use std::borrow::Cow;
-use std::char;
-use std::str;
-use std::string;
-use std::string::String as StdString;
+use alloc::borrow::Cow;
+use core::char;
+use core::str;
+use alloc::string;
+use alloc::string::String as StdString;
 
 use self::Token::*;
 
@@ -503,6 +503,9 @@ impl MaybeString {
     }
 
     fn to_owned(&mut self, input: &str) {
+        #[cfg(not(feature = "std"))]
+        use alloc::borrow::ToOwned;
+    
         match *self {
             MaybeString::NotEscaped(start) => {
                 *self = MaybeString::Owned(input[start..].to_owned());

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,8 +1,8 @@
 use alloc::borrow::Cow;
-use core::char;
-use core::str;
 use alloc::string;
 use alloc::string::String as StdString;
+use core::char;
+use core::str;
 
 use self::Token::*;
 
@@ -505,7 +505,7 @@ impl MaybeString {
     fn to_owned(&mut self, input: &str) {
         #[cfg(not(feature = "std"))]
         use alloc::borrow::ToOwned;
-    
+
         match *self {
             MaybeString::NotEscaped(start) => {
                 *self = MaybeString::Owned(input[start..].to_owned());

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,24 +1,24 @@
 //! Definition of a TOML value
 
 use alloc::collections::BTreeMap;
-use hashbrown::HashMap;
+use alloc::vec;
 use core::fmt;
 use core::hash::Hash;
 use core::mem::discriminant;
 use core::ops;
 use core::str::FromStr;
-use alloc::vec;
+use hashbrown::HashMap;
 
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::borrow::ToOwned;
 #[cfg(not(feature = "std"))]
 use alloc::format;
 #[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
 use alloc::string::ToString;
 #[cfg(not(feature = "std"))]
-use alloc::borrow::ToOwned;
+use alloc::vec::Vec;
 
 use serde::de;
 use serde::de::IntoDeserializer;

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,12 +1,24 @@
 //! Definition of a TOML value
 
-use std::collections::{BTreeMap, HashMap};
-use std::fmt;
-use std::hash::Hash;
-use std::mem::discriminant;
-use std::ops;
-use std::str::FromStr;
-use std::vec;
+use alloc::collections::BTreeMap;
+use hashbrown::HashMap;
+use core::fmt;
+use core::hash::Hash;
+use core::mem::discriminant;
+use core::ops;
+use core::str::FromStr;
+use alloc::vec;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
 
 use serde::de;
 use serde::de::IntoDeserializer;


### PR DESCRIPTION
Following up on #389 

This PR adds the ability to use the library in a no_std context.
Tested it on my embedded setup and it works as expected.

Consequences:
- Extra feature added as default: `std`
- Imports are more complicated.
- Instead of using the std hashmap, the hashbrown hashmap is used. This shouldn't have any effects because it is the same hashmap that is used in the std.
Ideally https://github.com/rust-lang/rust/issues/56192 would be made.

The imports could be cleaned up. The Serde crate does this in its lib.rs, but I don't think that's really necessary.