### PR TITLE
Allow delimiter quotes at the end of multiline strings

### DIFF
--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -334,7 +334,7 @@ impl<'a> Tokenizer<'a> {
                         return Err(Error::NewlineInString(i));
                     }
                 }
-                Some((i, ch)) if ch == delim => {
+                Some((mut i, ch)) if ch == delim => {
                     if multiline {
                         if !self.eatc(delim) {
                             val.push(delim);
@@ -344,6 +344,14 @@ impl<'a> Tokenizer<'a> {
                             val.push(delim);
                             val.push(delim);
                             continue 'outer;
+                        }
+                        if self.eatc(delim) {
+                            val.push(delim);
+                            i += 1;
+                        }
+                        if self.eatc(delim) {
+                            val.push(delim);
+                            i += 1;
                         }
                     }
                     return Ok(String {

--- a/test-suite/tests/valid.rs
+++ b/test-suite/tests/valid.rs
@@ -389,3 +389,9 @@ test!(
     include_str!("valid/float-exponent.toml"),
     include_str!("valid/float-exponent.json")
 );
+
+test!(
+    string_delim_end,
+    include_str!("valid/string-delim-end.toml"),
+    include_str!("valid/string-delim-end.json")
+);

--- a/test-suite/tests/valid/string-delim-end.json
+++ b/test-suite/tests/valid/string-delim-end.json
@@ -1,0 +1,14 @@
+{
+  "str1": {
+    "type": "string",
+    "value": "\"This,\" she said, \"is just a pointless statement.\""
+  },
+  "str2": {
+    "type": "string",
+    "value": "foo''bar''"
+  },
+  "str3": {
+    "type": "string",
+    "value": "\"\""
+  }
+}

--- a/test-suite/tests/valid/string-delim-end.toml
+++ b/test-suite/tests/valid/string-delim-end.toml
@@ -1,0 +1,3 @@
+str1 = """"This," she said, "is just a pointless statement.""""
+str2 = '''foo''bar'''''
+str3 = """"""""


### PR DESCRIPTION
TOML allows (unlike many other formats) up to 2
additonal quotes that are part of the string:

```
basic = """2 extra quotes -->"""""
literal = '''here too ''''
```

Changed in TOML v1.0.0-rc.1

See also #392