### PR TITLE
Show `Spanned` and `Datetime` in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,7 +171,6 @@ mod tokens;
 pub mod macros;
 
 mod spanned;
-#[doc(no_inline)]
 pub use crate::spanned::Spanned;
 
 // Just for rustdoc

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,7 +13,6 @@ use serde::de::IntoDeserializer;
 use serde::ser;
 
 use crate::datetime::{self, DatetimeFromString};
-#[doc(no_inline)]
 pub use crate::datetime::{Datetime, DatetimeParseError};
 
 pub use crate::map::Map;


### PR DESCRIPTION
Removes `#[doc(no_inline)]` from the `Spanned` re-export in `lib.rs` and from the `Datetime*` re-exports in `value.rs`

Resolves #408 