### PR TITLE
Use `constant` instead of `static` in a couple places

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -345,7 +345,7 @@ impl<'de> de::Deserialize<'de> for Datetime {
             }
         }
 
-        static FIELDS: [&str; 1] = [FIELD];
+        const FIELDS: [&str; 1] = [FIELD];
         deserializer.deserialize_struct(NAME, &FIELDS, DatetimeVisitor)
     }
 }

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -153,7 +153,7 @@ where
 
         let visitor = SpannedVisitor(::std::marker::PhantomData);
 
-        static FIELDS: [&str; 3] = [START, END, VALUE];
+        const FIELDS: [&str; 3] = [START, END, VALUE];
         deserializer.deserialize_struct(NAME, &FIELDS, visitor)
     }
 }


### PR DESCRIPTION
This keeps symbols for these from accidently being exported as easily.