### PR TITLE
Introduce deserialize_datetime_as_string feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,9 @@ default = []
 # This allows data to be read into a Value and written back to a TOML string
 # while preserving the order of map keys in the input.
 preserve_order = ["indexmap"]
+
+# If you use toml::de::Deserializer with a serde::de::Deserialize
+# implementation of another crate, you can enable the following flag to
+# deserialize datetime values as strings, instead of the special encoding
+# this crate normally uses behind the scenes.
+deserialize_datetime_as_string = []

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -21,6 +21,8 @@ use serde::{de, ser};
 /// Also note though that while this type implements `Serialize` and
 /// `Deserialize` it's only recommended to use this type with the TOML format,
 /// otherwise encoded in other formats it may look a little odd.
+/// If you want to deserialize TOML datetimes into a format other than TOML,
+/// you should use the `deserialize_datetime_as_string` feature flag.
 #[derive(PartialEq, Clone)]
 pub struct Datetime {
     date: Option<Date>,

--- a/src/de.rs
+++ b/src/de.rs
@@ -1480,14 +1480,20 @@ impl<'a> Deserializer<'a> {
         {
             self.datetime(span, s, false)
                 .map(|(Span { start, end }, d)| Value {
+                    #[cfg(not(feature = "deserialize_datetime_as_string"))]
                     e: E::Datetime(d),
+                    #[cfg(feature = "deserialize_datetime_as_string")]
+                    e: E::String(d.into()),
                     start,
                     end,
                 })
         } else if self.eat(Token::Colon)? {
             self.datetime(span, s, true)
                 .map(|(Span { start, end }, d)| Value {
+                    #[cfg(not(feature = "deserialize_datetime_as_string"))]
                     e: E::Datetime(d),
+                    #[cfg(feature = "deserialize_datetime_as_string")]
+                    e: E::String(d.into()),
                     start,
                     end,
                 })


### PR DESCRIPTION
When using the Deserializer implementation of this crate
with a serde::de::Deserialize implementation of another crate,
you don't want e.g. 2021-04-03 to become

{"$__toml_private_datetime" = "2021-04-03"}

(which is the special encoding this crate uses to represent
datetimes since serde's data model lacks a type for datetimes)

This commit introduces an off by default feature flag to deserialize
datetimes as strings if so desired, making it feasible to use
the toml crate with other Deserialize implementations without
leaking the above internal representation.

Closes #423.