### PR TITLE
Fix serialization of -0.0.

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -751,17 +751,21 @@ impl<'a> Serializer<'a> {
 macro_rules! serialize_float {
     ($this:expr, $v:expr) => {{
         $this.emit_key(ArrayState::Started)?;
-        if ($v.is_nan() || $v == 0.0) && $v.is_sign_negative() {
-            write!($this.dst, "-").map_err(ser::Error::custom)?;
+        match ($v.is_sign_negative(), $v.is_nan(), $v == 0.0) {
+            (true, true, _) => write!($this.dst, "-nan"),
+            (false, true, _) => write!($this.dst, "nan"),
+            (true, false, true) => write!($this.dst, "-0.0"),
+            (false, false, true) => write!($this.dst, "0.0"),
+            (_, false, false) => write!($this.dst, "{}", $v).and_then(|_| {
+                if $v % 1.0 == 0.0 {
+                    write!($this.dst, ".0")
+                } else {
+                    Ok(())
+                }
+            }),
         }
-        if $v.is_nan() {
-            write!($this.dst, "nan").map_err(ser::Error::custom)?;
-        } else {
-            write!($this.dst, "{}", $v).map_err(ser::Error::custom)?;
-        }
-        if $v % 1.0 == 0.0 {
-            write!($this.dst, ".0").map_err(ser::Error::custom)?;
-        }
+        .map_err(ser::Error::custom)?;
+
         if let State::Table { .. } = $this.state {
             $this.dst.push_str("\n");
         }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/78618 changed the display behavior of `-0.0` to include the `-` symbol which caused the serialization code to emit `--0.0`.
