### PR TITLE
Support use without libstd (e.g. alloc + core only)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
       run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: cargo test
     - run: cargo test --features preserve_order
+    - run: cargo test --no-default-features
+    - run: cargo test --no-default-features --features preserve_order
     - run: cargo test --manifest-path test-suite/Cargo.toml
     - run: cargo bench
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ edition = "2018"
 members = ['test-suite']
 
 [dependencies]
-serde = "1.0.97"
+serde = { version = "1.0.97", default-features = false }
 indexmap = { version = "1.0", optional = true }
 
 [dev-dependencies]
@@ -28,7 +28,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 
 [features]
-default = []
+default = ["std"]
+std = ["serde/std"]
 
 # Use indexmap rather than BTreeMap as the map type of toml::Value.
 # This allows data to be read into a Value and written back to a TOML string

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,6 +1,7 @@
-use std::error;
-use std::fmt;
-use std::str::{self, FromStr};
+use alloc::format;
+use alloc::string::ToString;
+use core::fmt;
+use core::str::{self, FromStr};
 
 use serde::{de, ser};
 
@@ -421,5 +422,5 @@ impl fmt::Display for DatetimeParseError {
         "failed to parse datetime".fmt(f)
     }
 }
-
-impl error::Error for DatetimeParseError {}
+#[cfg(feature = "std")]
+impl std::error::Error for DatetimeParseError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,9 @@
 // and lets them ensure that there is indeed no unsafe code as opposed to
 // something they couldn't detect (e.g. unsafe added via macro expansion, etc).
 #![forbid(unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 pub mod map;
 pub mod value;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+use alloc::borrow::ToOwned;
+pub use core::f64::{INFINITY, NAN, NEG_INFINITY};
 pub use serde::de::{Deserialize, IntoDeserializer};
 
 use crate::value::{Array, Table, Value};
@@ -199,27 +201,27 @@ macro_rules! toml_internal {
     }};
 
     (@value (-nan)) => {
-        $crate::Value::Float(-::std::f64::NAN)
+        $crate::Value::Float(-$crate::macros::NAN)
     };
 
     (@value (nan)) => {
-        $crate::Value::Float(::std::f64::NAN)
+        $crate::Value::Float($crate::macros::NAN)
     };
 
     (@value nan) => {
-        $crate::Value::Float(::std::f64::NAN)
+        $crate::Value::Float($crate::macros::NAN)
     };
 
     (@value (-inf)) => {
-        $crate::Value::Float(::std::f64::NEG_INFINITY)
+        $crate::Value::Float($crate::macros::NEG_INFINITY)
     };
 
     (@value (inf)) => {
-        $crate::Value::Float(::std::f64::INFINITY)
+        $crate::Value::Float($crate::macros::INFINITY)
     };
 
     (@value inf) => {
-        $crate::Value::Float(::std::f64::INFINITY)
+        $crate::Value::Float($crate::macros::INFINITY)
     };
 
     // Construct a Value from any other type, probably string or boolean or number.

--- a/src/map.rs
+++ b/src/map.rs
@@ -15,15 +15,16 @@
 //! [`LinkedHashMap`]: https://docs.rs/linked-hash-map/*/linked_hash_map/struct.LinkedHashMap.html
 
 use crate::value::Value;
+use alloc::string::String;
+use core::borrow::Borrow;
+use core::fmt::{self, Debug};
+use core::hash::Hash;
+use core::iter::FromIterator;
+use core::ops;
 use serde::{de, ser};
-use std::borrow::Borrow;
-use std::fmt::{self, Debug};
-use std::hash::Hash;
-use std::iter::FromIterator;
-use std::ops;
 
 #[cfg(not(feature = "preserve_order"))]
-use std::collections::{btree_map, BTreeMap};
+use alloc::collections::{btree_map, BTreeMap};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -144,10 +145,10 @@ impl Map<String, Value> {
     where
         S: Into<String>,
     {
+        #[cfg(not(feature = "preserve_order"))]
+        use alloc::collections::btree_map::Entry as EntryImpl;
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
-        #[cfg(not(feature = "preserve_order"))]
-        use std::collections::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant }),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -25,11 +25,12 @@
 //! # fn main() {}
 //! ```
 
-use std::cell::Cell;
-use std::error;
-use std::fmt::{self, Write};
-use std::marker;
-use std::rc::Rc;
+use alloc::rc::Rc;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::cell::Cell;
+use core::fmt::{self, Write};
+use core::marker;
 
 use crate::datetime;
 use serde::ser;
@@ -1547,8 +1548,8 @@ impl fmt::Display for Error {
         }
     }
 }
-
-impl error::Error for Error {}
+// See the comment on the `StdError` impl in de.rs for an explanation.
+impl serde::ser::StdError for Error {}
 
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {

--- a/src/spanned.rs
+++ b/src/spanned.rs
@@ -1,8 +1,9 @@
+use alloc::string::String;
+use core::borrow::Borrow;
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
 use serde::{de, ser};
-use std::borrow::Borrow;
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash::{Hash, Hasher};
 
 pub(crate) const NAME: &str = "$__toml_private_Spanned";
 pub(crate) const START: &str = "$__toml_private_start";
@@ -113,7 +114,7 @@ where
     where
         D: de::Deserializer<'de>,
     {
-        struct SpannedVisitor<T>(::std::marker::PhantomData<T>);
+        struct SpannedVisitor<T>(core::marker::PhantomData<T>);
 
         impl<'de, T> de::Visitor<'de> for SpannedVisitor<T>
         where
@@ -151,7 +152,7 @@ where
             }
         }
 
-        let visitor = SpannedVisitor(::std::marker::PhantomData);
+        let visitor = SpannedVisitor(core::marker::PhantomData);
 
         static FIELDS: [&str; 3] = [START, END, VALUE];
         deserializer.deserialize_struct(NAME, &FIELDS, visitor)

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,8 +1,8 @@
-use std::borrow::Cow;
-use std::char;
-use std::str;
-use std::string;
-use std::string::String as StdString;
+use alloc::borrow::{Cow, ToOwned};
+use alloc::string;
+use alloc::string::String as StdString;
+use core::char;
+use core::str;
 
 use self::Token::*;
 
@@ -561,7 +561,8 @@ impl<'a> Token<'a> {
 #[cfg(test)]
 mod tests {
     use super::{Error, Token, Tokenizer};
-    use std::borrow::Cow;
+    use alloc::borrow::Cow;
+    use alloc::vec::Vec;
 
     fn err(input: &str, err: Error) {
         let mut t = Tokenizer::new(input);

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,12 +1,16 @@
 //! Definition of a TOML value
 
-use std::collections::{BTreeMap, HashMap};
-use std::fmt;
-use std::hash::Hash;
-use std::mem::discriminant;
-use std::ops;
-use std::str::FromStr;
-use std::vec;
+use alloc::borrow::ToOwned;
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::{self, Vec};
+use core::fmt;
+use core::mem::discriminant;
+use core::ops;
+use core::str::FromStr;
+#[cfg(feature = "std")]
+use std::{collections::HashMap, hash::Hash};
 
 use serde::de;
 use serde::de::IntoDeserializer;
@@ -271,6 +275,7 @@ impl<S: Into<String>, V: Into<Value>> From<BTreeMap<S, V>> for Value {
     }
 }
 
+#[cfg(feature = "std")]
 impl<S: Into<String> + Hash + Eq, V: Into<Value>> From<HashMap<S, V>> for Value {
     fn from(val: HashMap<S, V>) -> Value {
         let table = val.into_iter().map(|(s, v)| (s.into(), v.into())).collect();


### PR DESCRIPTION
This allows using toml for config files in some scenarios where e.g. porting libstd isn't really viable or would be painful, but where a small memory allocator is easy.