### PR TITLE
Fix missing empty line between tables

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -934,10 +934,15 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
         self.array_type(ArrayState::StartedAsATable)?;
+        let first = match self.state {
+            State::Table { first, .. } => first.get(),
+            State::Array { first, .. } => first.get(),
+            State::End => true,
+        };
         Ok(SerializeTable::Table {
             ser: self,
             key: String::new(),
-            first: Cell::new(true),
+            first: Cell::new(first),
             table_emitted: Cell::new(false),
         })
     }

--- a/tests/map_formtting.rs
+++ b/tests/map_formtting.rs
@@ -1,0 +1,69 @@
+// Test copied from https://github.com/alexcrichton/toml-rs/issues/219
+
+extern crate serde;
+#[macro_use] extern crate serde_derive;
+extern crate toml;
+
+use std::collections::HashMap;
+
+
+#[derive(Serialize, Deserialize)]
+struct Foo {
+    bar: Bar,
+    baz: HashMap<String, Bar>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct FooSwapped {
+    baz: HashMap<String, Bar>,
+    bar: Bar,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Bar {
+    foo: u32
+}
+
+#[test]
+fn tables_separated_by_empty_lines() {
+    let expected = "[bar]
+foo = 42
+
+[baz.a]
+foo = 0
+";
+
+    let mut baz = HashMap::new();
+    baz.insert("a".into(), Bar { foo: 0 });
+
+    let foo = Foo {
+        bar: Bar {
+            foo: 42,
+        },
+        baz: baz,
+    };
+
+    assert_eq!(toml::to_string_pretty(&foo).unwrap(), expected);
+}
+
+#[test]
+fn tables_separated_by_empty_lines_swapped() {
+    let expected = "[baz.a]
+foo = 0
+
+[bar]
+foo = 42
+";
+
+    let mut baz = HashMap::new();
+    baz.insert("a".into(), Bar { foo: 0 });
+
+    let foo = FooSwapped {
+        bar: Bar {
+            foo: 42,
+        },
+        baz: baz,
+    };
+
+    assert_eq!(toml::to_string_pretty(&foo).unwrap(), expected);
+}


### PR DESCRIPTION
This adds empty line that was missing between tables, specifically
between struct and map. It also adds test to catch those cases.

Closes #219