### PR TITLE
Use entry api to remove a lookup in deserialisation loop

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -15,7 +15,7 @@ use serde::ser;
 use crate::datetime::{self, DatetimeFromString};
 pub use crate::datetime::{Datetime, DatetimeParseError};
 
-pub use crate::map::{Map, Entry};
+pub use crate::map::{Entry, Map};
 
 /// Representation of a TOML value.
 #[derive(PartialEq, Clone, Debug)]

--- a/src/value.rs
+++ b/src/value.rs
@@ -15,7 +15,7 @@ use serde::ser;
 use crate::datetime::{self, DatetimeFromString};
 pub use crate::datetime::{Datetime, DatetimeParseError};
 
-pub use crate::map::Map;
+pub use crate::map::{Map, Entry};
 
 /// Representation of a TOML value.
 #[derive(PartialEq, Clone, Debug)]
@@ -526,12 +526,13 @@ impl<'de> de::Deserialize<'de> for Value {
                 }
                 let mut map = Map::new();
                 map.insert(key, visitor.next_value()?);
-                while let Some(key) = visitor.next_key()? {
-                    if map.contains_key(&key) {
+                while let Some(key) = visitor.next_key::<String>()? {
+                    if let Entry::Vacant(vacant) = map.entry(&key) {
+                        vacant.insert(visitor.next_value()?);
+                    } else {
                         let msg = format!("duplicate key: `{}`", key);
                         return Err(de::Error::custom(msg));
                     }
-                    map.insert(key, visitor.next_value()?);
                 }
                 Ok(Value::Table(map))
             }


### PR DESCRIPTION
Was reading the source and this jumped out at me.
It's not much but deserialising toml faster seems like a good thing.