### PR TITLE
Partial ord datetime

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -207,9 +207,21 @@ impl fmt::Display for Datetime {
     }
 }
 
+impl fmt::Debug for Date {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
 impl fmt::Display for Date {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:04}-{:02}-{:02}", self.year, self.month, self.day)
+    }
+}
+
+impl fmt::Debug for Time {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 
@@ -221,6 +233,12 @@ impl fmt::Display for Time {
             write!(f, ".{}", s.trim_end_matches('0'))?;
         }
         Ok(())
+    }
+}
+
+impl fmt::Debug for Offset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
     }
 }
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -180,13 +180,6 @@ fn last_day_of_month(year: i16, month: i8) -> i8 {
     }
 }
 
-fn debug_line_ymdhm(line: usize, year: i16, month: i8, day: i8, hour: i8, minute: i8) {
-    println!(
-        "Line {:3}: {:4} {:2} {:2} {:2} {:2}",
-        line, year, month, day, hour, minute
-    );
-}
-
 /// Subtracts (hours, minutes) from the given date and time.
 ///
 /// Notes:
@@ -203,22 +196,18 @@ fn add_hours_minutes(date: &Date, time: &Time, hours: i8, minutes: i8) -> Dateti
     if minute < 0 {
         minute += 60;
         hour -= 1;
-        debug_line_ymdhm(200, year, month, day, hour, minute);
     } else if minute > 59 {
         minute -= 60;
         hour += 1;
-        debug_line_ymdhm(204, year, month, day, hour, minute);
     }
 
     hour += hours;
     if hour < 0 {
         hour += 24;
         day -= 1;
-        debug_line_ymdhm(211, year, month, day, hour, minute);
     } else if hour > 23 {
         hour -= 24;
         day += 1;
-        debug_line_ymdhm(215, year, month, day, hour, minute);
     }
 
     if day < 1 {
@@ -228,7 +217,6 @@ fn add_hours_minutes(date: &Date, time: &Time, hours: i8, minutes: i8) -> Dateti
             year -= 1;
         }
         day = last_day_of_month(year, month);
-        debug_line_ymdhm(225, year, month, day, hour, minute);
     } else if day > last_day_of_month(year, month) {
         day = 1;
         month += 1;
@@ -236,10 +224,8 @@ fn add_hours_minutes(date: &Date, time: &Time, hours: i8, minutes: i8) -> Dateti
             month = 1;
             year += 1;
         }
-        debug_line_ymdhm(233, year, month, day, hour, minute);
     }
 
-    debug_line_ymdhm(236, year, month, day, hour, minute);
     Datetime {
         date: Some(Date {
             year: year as u16,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -163,7 +163,9 @@ impl PartialOrd for Datetime {
     }
 }
 
-fn last_day(year: i16, month: i8) -> i8 {
+/// Returns the last day of a month. Requires the year as an argument because
+/// of the leap year exception that happens every 400 years.
+fn last_day_of_month(year: i16, month: i8) -> i8 {
     match month {
         1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
         4 | 6 | 9 | 11 => 30,
@@ -225,9 +227,9 @@ fn add_hours_minutes(date: &Date, time: &Time, hours: i8, minutes: i8) -> Dateti
             month = 12;
             year -= 1;
         }
-        day = last_day(year, month);
+        day = last_day_of_month(year, month);
         debug_line_ymdhm(225, year, month, day, hour, minute);
-    } else if day > last_day(year, month) {
+    } else if day > last_day_of_month(year, month) {
         day = 1;
         month += 1;
         if month == 13 {


### PR DESCRIPTION
Would the maintainers be interested in accepting this kind of PR...?

## Summary

I've implemented `PartialOrd` for `Date` and `Time`. I've started but not finished doing the same for `Datetime`. I'd like to outline my plan to get feedback.

*The Plan*: The only possibility for a non-`None` ordering happens between TOML *Offset Date-Time*s (i.e. cases where the `Datetime` struct has no `None` values). To compare such a pair (in `partial_cmp`), I plan to convert each to its UTC equivalent first. From there, a comparison is easy. Is this correct in all cases?

P.S. Apologies for an earlier duplicate; I closed it because it was based on the wrong branch.