### PR TITLE
Allow dead code in examples to fix CI build

### DIFF
--- a/examples/decode.rs
+++ b/examples/decode.rs
@@ -2,6 +2,7 @@
 //! TOML into a Rust `struct`
 
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use serde_derive::Deserialize;
 

--- a/examples/enum_external.rs
+++ b/examples/enum_external.rs
@@ -2,6 +2,7 @@
 //! TOML into a Rust `struct`, with enums.
 
 #![deny(warnings)]
+#![allow(dead_code)]
 
 use serde_derive::Deserialize;
 


### PR DESCRIPTION
The examples deny warnings, however a couple of examples deserialise TOML into
structs. The fields of these structs are never read, which breaks cargo test
in nightly mode.

Allow dead code to fix the CI build, as discussed on #447.