### PR TITLE
speedup, test and improve datetime parsing

### DIFF
--- a/test-suite/Cargo.toml
+++ b/test-suite/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2018"
 name = "linear"
 harness = false
 
+[[bench]]
+name = "datetime"
+harness = false
+
 [dev-dependencies]
 bencher = "0.1"
 toml = { path = ".." }

--- a/test-suite/benches/datetime.rs
+++ b/test-suite/benches/datetime.rs
@@ -1,0 +1,61 @@
+use bencher::{benchmark_group, benchmark_main, black_box, Bencher};
+use std::str::FromStr;
+use toml::value::Datetime;
+use toml::Value;
+
+fn dt_z(bench: &mut Bencher) {
+    let s = black_box("1997-09-09T09:09:09Z");
+    bench.iter(|| {
+        black_box(Datetime::from_str(&s).unwrap());
+    })
+}
+
+fn dt_custom_tz(bench: &mut Bencher) {
+    let s = black_box("1997-09-09T09:09:09-09:09");
+    bench.iter(|| {
+        black_box(Datetime::from_str(&s).unwrap());
+    })
+}
+
+fn dt_naive(bench: &mut Bencher) {
+    let s = black_box("1997-09-09T09:09:09");
+    bench.iter(|| {
+        black_box(Datetime::from_str(&s).unwrap());
+    })
+}
+
+fn date(bench: &mut Bencher) {
+    let s = black_box("1997-09-09");
+    bench.iter(|| {
+        black_box(Datetime::from_str(&s).unwrap());
+    })
+}
+
+fn time(bench: &mut Bencher) {
+    let s = black_box("09:09:09.09");
+    bench.iter(|| {
+        black_box(Datetime::from_str(&s).unwrap());
+    })
+}
+
+fn datetimes_as_toml(bench: &mut Bencher) {
+    let mut s = String::new();
+    s += "d1 = 1997-09-09T09:09:09Z\n";
+    s += "d2 = 1997-09-09T09:09:09-09:09\n";
+    s += "d3 = 09:09:09.09\n";
+    let s = black_box(s);
+    bench.iter(|| {
+        black_box(s.parse::<Value>().unwrap());
+    })
+}
+
+benchmark_group!(
+    benches,
+    dt_z,
+    dt_custom_tz,
+    dt_naive,
+    date,
+    time,
+    datetimes_as_toml
+);
+benchmark_main!(benches);

--- a/test-suite/tests/datetime.rs
+++ b/test-suite/tests/datetime.rs
@@ -1,6 +1,7 @@
 extern crate toml;
 
 use std::str::FromStr;
+use toml::value::{Date, Datetime, Offset, Time};
 
 macro_rules! bad {
     ($toml:expr, $msg:expr) => {
@@ -26,6 +27,7 @@ fn times() {
     }
 
     good("1997-09-09T09:09:09Z");
+    dogood("1997-09-09 09:09:09Z", "1997-09-09T09:09:09Z");
     good("1997-09-09T09:09:09+09:09");
     good("1997-09-09T09:09:09-09:09");
     good("1997-09-09T09:09:09");
@@ -38,6 +40,9 @@ fn times() {
     good("1997-09-09T09:09:09.09-09:09");
     good("1997-09-09T09:09:09.09");
     good("09:09:09.09");
+    good("2003-02-28T12:34:56Z");
+    good("2000-02-29T12:34:56Z");
+    good("2004-02-29T12:34:56Z");
 }
 
 #[test]
@@ -130,5 +135,112 @@ fn bad_times() {
     bad!(
         "foo = 1997-09-09T12:09:69.09Z",
         "failed to parse datetime for key `foo` at line 1 column 7"
+    );
+    bad!(
+        "foo = 2003-02-29T12:34:56Z",
+        "failed to parse datetime for key `foo` at line 1 column 7"
+    );
+    bad!(
+        "foo = 1900-02-29T12:34:56Z",
+        "failed to parse datetime for key `foo` at line 1 column 7"
+    );
+}
+
+#[test]
+fn datetime_custom_tz() {
+    assert_eq!(
+        Datetime::from_str("2015-06-26T16:43:23.123+02:00").unwrap(),
+        Datetime {
+            date: Some(Date {
+                year: 2015,
+                month: 6,
+                day: 26,
+            }),
+            time: Some(Time {
+                hour: 16,
+                minute: 43,
+                second: 23,
+                nanosecond: 123_000_000,
+            }),
+            offset: Some(Offset::Custom {
+                hours: 2,
+                minutes: 0,
+            }),
+        }
+    );
+}
+
+#[test]
+fn datetime_z() {
+    assert_eq!(
+        Datetime::from_str("2015-06-26T16:43:23Z").unwrap(),
+        Datetime {
+            date: Some(Date {
+                year: 2015,
+                month: 6,
+                day: 26,
+            }),
+            time: Some(Time {
+                hour: 16,
+                minute: 43,
+                second: 23,
+                nanosecond: 0,
+            }),
+            offset: Some(Offset::Z),
+        }
+    );
+}
+
+#[test]
+fn datetime_naive() {
+    assert_eq!(
+        Datetime::from_str("2015-06-26T16:43:23.001234").unwrap(),
+        Datetime {
+            date: Some(Date {
+                year: 2015,
+                month: 6,
+                day: 26,
+            }),
+            time: Some(Time {
+                hour: 16,
+                minute: 43,
+                second: 23,
+                nanosecond: 1_234_000,
+            }),
+            offset: None,
+        }
+    );
+}
+
+#[test]
+fn date() {
+    assert_eq!(
+        Datetime::from_str("2015-06-26").unwrap(),
+        Datetime {
+            date: Some(Date {
+                year: 2015,
+                month: 6,
+                day: 26,
+            }),
+            time: None,
+            offset: None,
+        }
+    );
+}
+
+#[test]
+fn time() {
+    assert_eq!(
+        Datetime::from_str("16:43:23.1").unwrap(),
+        Datetime {
+            date: None,
+            time: Some(Time {
+                hour: 16,
+                minute: 43,
+                second: 23,
+                nanosecond: 100_000_000,
+            }),
+            offset: None,
+        }
     );
 }


### PR DESCRIPTION
I was looking for a datetime parsing library for pydantic-core and tested the datetime parsing logic from this library, I found it was already significantly faster than both chrono and iso8601, however I also discovered some fairly trivial changes could improve the performance significantly.

Changes proposed here:
* process `.bytes()` instead of `.chars()`, I haven't (yet) renamed the variable from `chars` to `bytes` to keep the changes to a minimum, I can if requested
* make `digit` a macro, this seemed to improve performance a little
* change the logic in nanosecond calculation to adjust the base just once at the end
* calculate the correct number of days in each month correctly, accounting for leap years
* add tests for the `Datetime` struct created when parsing strings
* add benchmarks for parsing datetimes, dates and times

Combined these changes have the following effect on performance:

**Before:**

```
test date              ... bench:          13 ns/iter (+/- 2)
test datetimes_as_toml ... bench:       2,316 ns/iter (+/- 11)
test dt_custom_tz      ... bench:          39 ns/iter (+/- 2)
test dt_naive          ... bench:          26 ns/iter (+/- 1)
test dt_z              ... bench:          26 ns/iter (+/- 1)
test time              ... bench:          16 ns/iter (+/- 0)
```

**After:**
```
test date              ... bench:           6 ns/iter (+/- 0)
test datetimes_as_toml ... bench:       2,250 ns/iter (+/- 8)
test dt_custom_tz      ... bench:          14 ns/iter (+/- 0)
test dt_naive          ... bench:          11 ns/iter (+/- 0)
test dt_z              ... bench:          12 ns/iter (+/- 0)
test time              ... bench:           9 ns/iter (+/- 0)
```