### PR TITLE
Add support for enum variants with parameters, fixes dotted tables as well

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -687,8 +687,6 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     where
         V: de::Visitor<'de>,
     {
-
-
         let table = &mut self.tables[0];
 
         let mut values = match table.values.take() {
@@ -745,7 +743,6 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
                 })
             }
         }
-
     }
 
     serde::forward_to_deserialize_any! {

--- a/src/de.rs
+++ b/src/de.rs
@@ -320,8 +320,8 @@ impl<'de, 'b> de::Deserializer<'de> for &'b mut Deserializer<'de> {
         _name: &'static str,
         visitor: V,
     ) -> Result<V::Value, crate::de::Error>
-        where
-            V: de::Visitor<'de>,
+    where
+        V: de::Visitor<'de>,
     {
         visitor.visit_newtype_struct(self)
     }
@@ -687,13 +687,13 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
     where
         V: de::Visitor<'de>,
     {
+
+
         let table = &mut self.tables[0];
-
-
 
         let mut values = match table.values.take() {
             None => self.values.collect(),
-            Some(v) => v
+            Some(v) => v,
         };
         if table.header.is_empty() {
             return Err(self.de.error(self.cur, ErrorKind::EmptyTableKey));
@@ -709,18 +709,24 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
         let value = values.remove(0);
 
         match value {
-            ((_, name), Value {start, end, e: E::InlineTable(mut pairs)}) if pairs.len() == 1 => {
-                visitor.visit_enum(DottedTableDeserializer {
-                    name: name,
-                    value: Value {start, end, e: E::InlineTable(pairs) }
-                })
-            },
+            (
+                (_, name),
+                Value {
+                    start,
+                    end,
+                    e: E::InlineTable(mut pairs),
+                },
+            ) if pairs.len() == 1 => visitor.visit_enum(DottedTableDeserializer {
+                name: name,
+                value: Value {
+                    start,
+                    end,
+                    e: E::InlineTable(pairs),
+                },
+            }),
             ((_, name), value) if table.header.len() == 1 => {
-                visitor.visit_enum(DottedTableDeserializer {
-                    name,
-                    value,
-                })
-            },
+                visitor.visit_enum(DottedTableDeserializer { name, value })
+            }
 
             value => {
                 let header = table.header.last().unwrap().clone();
@@ -734,8 +740,8 @@ impl<'de, 'b> de::Deserializer<'de> for MapVisitor<'de, 'b> {
                     value: Value {
                         e: E::DottedTable(values),
                         start: header.0.start,
-                        end: header.0.end
-                    }
+                        end: header.0.end,
+                    },
                 })
             }
         }
@@ -1281,16 +1287,14 @@ impl<'de> de::VariantAccess<'de> for TableEnumDeserializer<'de> {
                     ))
                 }
             }
-            E::Array(values) => {
-                de::Deserializer::deserialize_seq(
-                    ValueDeserializer::new( Value {
-                        e: E::Array(values),
-                        start: self.value.start,
-                        end: self.value.end,
-                    }),
-                    visitor,
-                )
-            },
+            E::Array(values) => de::Deserializer::deserialize_seq(
+                ValueDeserializer::new(Value {
+                    e: E::Array(values),
+                    start: self.value.start,
+                    end: self.value.end,
+                }),
+                visitor,
+            ),
             e => Err(Error::from_kind(
                 Some(self.value.start),
                 ErrorKind::Wanted {
@@ -1522,6 +1526,7 @@ impl<'a> Deserializer<'a> {
         }
 
         let first_char = key.chars().next().expect("key should not be empty here");
+
         match first_char {
             '-' | '0'..='9' => self.number_or_date(span, key),
             _ => Err(self.error(at, ErrorKind::UnquotedString)),

--- a/src/de.rs
+++ b/src/de.rs
@@ -2322,14 +2322,14 @@ impl<'a> Header<'a> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Value<'a> {
     e: E<'a>,
     start: usize,
     end: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum E<'a> {
     Integer(i64),
     Float(f64),

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -239,9 +239,8 @@ pub struct SerializeVariantSeq<'a, 'b> {
     first: Cell<bool>,
     type_: Cell<Option<ArrayState>>,
     table_emitted: Cell<bool>,
-    len: Option<usize>
+    len: Option<usize>,
 }
-
 
 #[doc(hidden)]
 pub enum SerializeTable<'a, 'b> {
@@ -712,7 +711,6 @@ impl<'a> Serializer<'a> {
                 self.emit_table_header(parent)?;
                 break;
             }
-
         }
 
         match *state {
@@ -958,12 +956,12 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
         self.array_type(ArrayState::Started)?;
 
         Ok(SerializeVariantSeq {
-                ser: self,
-                variant,
-                first: Cell::new(true),
-                type_: Cell::new(None),
-                table_emitted: Cell::new(false),
-                len: Some(len)
+            ser: self,
+            variant,
+            first: Cell::new(true),
+            type_: Cell::new(None),
+            table_emitted: Cell::new(false),
+            len: Some(len),
         })
     }
 
@@ -1098,7 +1096,6 @@ impl<'a, 'b> ser::SerializeTupleVariant for SerializeVariantSeq<'a, 'b> {
             table_emitted: &self.table_emitted,
         };
 
-
         value.serialize(&mut Serializer {
             dst: self.ser.dst,
             state: State::Array {
@@ -1190,16 +1187,23 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
                 ref table_emitted,
                 ..
             } => {
-                let Serializer {dst, state, settings} = ser;
+                let Serializer {
+                    dst,
+                    state,
+                    settings,
+                } = ser;
                 let inner_table_emitted = Cell::new(false);
                 let inner_first = Cell::new(false);
 
-                let parent = prefix.as_ref().map(|p| State::Table {
-                    key: p,
-                    parent: &state,
-                    first: &inner_first,
-                    table_emitted: &inner_table_emitted
-                }).unwrap_or(state.clone());
+                let parent = prefix
+                    .as_ref()
+                    .map(|p| State::Table {
+                        key: p,
+                        parent: &state,
+                        first: &inner_first,
+                        table_emitted: &inner_table_emitted,
+                    })
+                    .unwrap_or(state.clone());
 
                 let res = value.serialize(&mut Serializer {
                     dst,
@@ -1239,7 +1243,14 @@ impl<'a, 'b> ser::SerializeStructVariant for SerializeTable<'a, 'b> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> where T: ser::Serialize {
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        key: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
+    where
+        T: ser::Serialize,
+    {
         ser::SerializeStruct::serialize_field(self, key, value)
     }
 
@@ -1247,7 +1258,6 @@ impl<'a, 'b> ser::SerializeStructVariant for SerializeTable<'a, 'b> {
         ser::SerializeStruct::end(self)
     }
 }
-
 
 impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
     type Ok = ();
@@ -1272,14 +1282,21 @@ impl<'a, 'b> ser::SerializeStruct for SerializeTable<'a, 'b> {
                 ref table_emitted,
                 ..
             } => {
-                let Serializer {dst, state, settings} = ser;
+                let Serializer {
+                    dst,
+                    state,
+                    settings,
+                } = ser;
                 let parent_emitted = Cell::new(false);
-                let parent = prefix.as_ref().map(|p| State::Table {
-                    key: p,
-                    parent: &state,
-                    first,
-                    table_emitted: &parent_emitted
-                }).unwrap_or(state.clone());
+                let parent = prefix
+                    .as_ref()
+                    .map(|p| State::Table {
+                        key: p,
+                        parent: &state,
+                        first,
+                        table_emitted: &parent_emitted,
+                    })
+                    .unwrap_or(state.clone());
 
                 let res = value.serialize(&mut Serializer {
                     dst,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -920,7 +920,6 @@ impl<'a, 'b> ser::Serializer for &'b mut Serializer<'a> {
     where
         T: ser::Serialize,
     {
-        println!("serialize_newtype_variant {:?}", variant);
         let mut s = self.serialize_map(Some(1))?;
         ser::SerializeStruct::serialize_field(&mut s, variant, value)?;
         ser::SerializeStruct::end(s)?;
@@ -1191,7 +1190,6 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
                 ref table_emitted,
                 ..
             } => {
-                println!("serialize_value of SerializeMap prefix = {:?}, key={:?}", prefix, key);
                 let Serializer {dst, state, settings} = ser;
                 let inner_table_emitted = Cell::new(false);
                 let inner_first = Cell::new(false);

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -703,6 +703,16 @@ impl<'a> Serializer<'a> {
                 self.emit_table_header(parent)?;
                 break;
             }
+
+            if let State::Array {
+                parent: &State::Table { .. },
+                ..
+            } = *parent
+            {
+                self.emit_table_header(parent)?;
+                break;
+            }
+
         }
 
         match *state {
@@ -1183,10 +1193,13 @@ impl<'a, 'b> ser::SerializeMap for SerializeTable<'a, 'b> {
             } => {
                 println!("serialize_value of SerializeMap prefix = {:?}, key={:?}", prefix, key);
                 let Serializer {dst, state, settings} = ser;
+                let inner_table_emitted = Cell::new(false);
+                let inner_first = Cell::new(false);
+
                 let parent = prefix.as_ref().map(|p| State::Table {
                     key: p,
                     parent: &state,
-                    first,
+                    first: &inner_first,
                     table_emitted: &inner_table_emitted
                 }).unwrap_or(state.clone());
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -33,7 +33,6 @@ use std::rc::Rc;
 
 use crate::datetime;
 use serde::ser;
-use serde::Serialize;
 
 /// Serialize the given data structure as a TOML byte vector.
 ///
@@ -1229,7 +1228,7 @@ impl<'a, 'b> ser::SerializeStructVariant for SerializeTable<'a, 'b> {
     type Ok = ();
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> where T: Serialize {
+    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error> where T: ser::Serialize {
         ser::SerializeStruct::serialize_field(self, key, value)
     }
 
@@ -1984,7 +1983,7 @@ impl<E: ser::Error> ser::SerializeStructVariant for Categorize<E> {
         value: &T,
     ) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ser::Serialize,
     {
         Ok(())
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -962,7 +962,6 @@ impl ser::SerializeStructVariant for SerializeVariantMap {
     }
 }
 
-
 impl ser::SerializeTupleVariant for SerializeVariantVec {
     type Ok = Value;
     type Error = crate::ser::Error;

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -589,6 +589,9 @@ fn enum_with_different_constructors() {
     };
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+    struct VecWrapper { aa: Vec<A> };
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
     enum A {
         A1,
         A2(u64),
@@ -673,31 +676,31 @@ fn enum_with_different_constructors() {
         }),
     }
 
-    // equivalent! {
-    //     VecWrapper{ aa: vec![A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))}, A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))}] },
-    //     Table(map! {
-    //         aa: Array(vec![
-    //             Table(map! {
-    //                 A7: Table(map! {
-    //                     a7: Table(map! {
-    //                         x: Integer(1),
-    //                         y: Integer(2),
-    //                         z: Integer(3)
-    //                     })
-    //                 })
-    //             }),
-    //             Table(map! {
-    //                 A7: Table(map! {
-    //                     a7: Table(map! {
-    //                         x: Integer(1),
-    //                         y: Integer(2),
-    //                         z: Integer(3)
-    //                     })
-    //                 })
-    //             })
-    //         ])
-    //     }),
-    // }
+    equivalent! {
+        VecWrapper{ aa: vec![A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))}, A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))}] },
+        Table(map! {
+            aa: Array(vec![
+                Table(map! {
+                    A7: Table(map! {
+                        a7: Table(map! {
+                            x: Integer(1),
+                            y: Integer(2),
+                            z: Integer(3)
+                        })
+                    })
+                }),
+                Table(map! {
+                    A7: Table(map! {
+                        a7: Table(map! {
+                            x: Integer(1),
+                            y: Integer(2),
+                            z: Integer(3)
+                        })
+                    })
+                })
+            ])
+        }),
+    }
 
 }
 

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -589,9 +589,9 @@ fn enum_with_different_constructors() {
         A2(u64),
         A3 { a3: u64 },
         A4(u64, String),
-        A5 { a51: u64, a52: String},
+        A5 { a51: u64, a52: String },
         A6(B),
-        A7 { a7: B},
+        A7 { a7: B },
     }
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
@@ -625,7 +625,7 @@ fn enum_with_different_constructors() {
     equivalent! {
         A::A4(42, String::from("foo")),
         Table(map! {
-            a4: Array(vec![Integer(42), Value::String("foo".to_string()))
+            a4: Array(vec![Integer(42), Value::String("foo".to_string())])
         })
     }
 
@@ -660,9 +660,6 @@ fn enum_with_different_constructors() {
             })
         })
     }
-
-
-
 }
 
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -589,7 +589,9 @@ fn enum_with_different_constructors() {
     };
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
-    struct VecWrapper { aa: Vec<A> };
+    struct VecWrapper {
+        aa: Vec<A>,
+    };
 
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
     enum A {
@@ -701,7 +703,6 @@ fn enum_with_different_constructors() {
             ])
         }),
     }
-
 }
 
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -623,31 +623,31 @@ fn enum_with_different_constructors() {
         }),
     }
 
-    // equivalent! {
-    //     A::A3 { a3: 42 },
-    //     Table(map! {
-    //         A3: Table(map! {
-    //             a3: 42
-    //         })
-    //     }),
-    // }
+    equivalent! {
+        A::A3 { a3: 42 },
+        Table(map! {
+            A3: Table(map! {
+                a3: 42
+            })
+        }),
+    }
 
-    // equivalent! {
-    //     A::A4(42, String::from("foo")),
-    //     Table(map! {
-    //         A4: Array(vec![Integer(42), Value::String("foo".to_string())])
-    //     }),
-    // }
+    equivalent! {
+        A::A4(42, String::from("foo")),
+        Table(map! {
+            A4: Array(vec![Integer(42), Value::String("foo".to_string())])
+        }),
+    }
 
-    // equivalent! {
-    //     A::A5 { a51: 42, a52: String::from("foo") },
-    //     Table(map! {
-    //         A5: Table(map! {
-    //             a51: Integer(42),
-    //             a52: Value::String("foo".to_string())
-    //         })
-    //     }),
-    // }
+    equivalent! {
+        A::A5 { a51: 42, a52: String::from("foo") },
+        Table(map! {
+            A5: Table(map! {
+                a51: Integer(42),
+                a52: Value::String("foo".to_string())
+            })
+        }),
+    }
 
     equivalent! {
         A::A6(B(Some(C {x: 1, y:2, z: 3}))),
@@ -660,18 +660,45 @@ fn enum_with_different_constructors() {
         }),
     }
 
+    equivalent! {
+        A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))},
+        Table(map! {
+            A7: Table(map! {
+                a7: Table(map! {
+                    x: Integer(1),
+                    y: Integer(2),
+                    z: Integer(3)
+                })
+            })
+        }),
+    }
+
     // equivalent! {
-    //     A::A7{ a7: B(Some(C {x: 1, y:2, z: 3}))},
+    //     VecWrapper{ aa: vec![A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))}, A::A7 { a7: B(Some(C {x: 1, y:2, z: 3}))}] },
     //     Table(map! {
-    //         A7: Table(map! {
-    //             a7: Table(map! {
-    //                 x: Integer(1),
-    //                 y: Integer(2),
-    //                 z: Integer(3)
+    //         aa: Array(vec![
+    //             Table(map! {
+    //                 A7: Table(map! {
+    //                     a7: Table(map! {
+    //                         x: Integer(1),
+    //                         y: Integer(2),
+    //                         z: Integer(3)
+    //                     })
+    //                 })
+    //             }),
+    //             Table(map! {
+    //                 A7: Table(map! {
+    //                     a7: Table(map! {
+    //                         x: Integer(1),
+    //                         y: Integer(2),
+    //                         z: Integer(3)
+    //                     })
+    //                 })
     //             })
-    //         })
+    //         ])
     //     }),
     // }
+
 }
 
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -584,6 +584,11 @@ fn newtypes2() {
 #[test]
 fn enum_with_different_constructors() {
     #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+    struct Wrapper {
+        a: A,
+    };
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
     enum A {
         A1,
         A2(u64),
@@ -605,60 +610,67 @@ fn enum_with_different_constructors() {
     }
 
     equivalent! {
-        A::A1, String("A1")
+        Wrapper { a: A::A1 },
+        Table(map! {
+            a: Value::String("A1".to_string())
+        }),
     }
 
     equivalent! {
         A::A2(42),
         Table(map! {
-            a2: Array(vec![Integer(42)])
-        })
+            A2: Array(vec![Integer(42)])
+        }),
     }
 
     equivalent! {
         A::A3 { a3: 42 },
         Table(map! {
-            a3: [42]
-        })
+            A3: Table(map! {
+                a3: 42
+            })
+        }),
     }
 
     equivalent! {
         A::A4(42, String::from("foo")),
         Table(map! {
-            a4: Array(vec![Integer(42), Value::String("foo".to_string())])
-        })
+            A4: Array(vec![Integer(42), Value::String("foo".to_string())])
+        }),
     }
 
     equivalent! {
         A::A5 { a51: 42, a52: String::from("foo") },
         Table(map! {
-            a5: Table(map! {
+            A5: Table(map! {
                 a51: Integer(42),
                 a52: Value::String("foo".to_string())
             })
-        })
+        }),
     }
 
     equivalent! {
-        A::A6(Some({x: 1, y:2, z: 3})),
+        A::A6(B(Some(C {x: 1, y:2, z: 3}))),
         Table(map! {
-            a6: Table(map! {
+            A6: Table(map! {
                 x: Integer(1),
                 y: Integer(2),
                 z: Integer(3)
             })
-        })
+        }),
     }
 
     equivalent! {
-        A::A7{ a7: Some({x: 1, y:2, z: 3})},
+        A::A7{ a7: B(Some(C {x: 1, y:2, z: 3}))},
         Table(map! {
-            a7: Table(map! {
-                x: Integer(1),
-                y: Integer(2),
-                z: Integer(3)
+            A7: Table(map! {
+                a7: Table(map! {
+                    x: Integer(1),
+                    y: Integer(2),
+                    z: Integer(3)
+                })
             })
-        })
+        }),
     }
 }
 

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -581,6 +581,90 @@ fn newtypes2() {
     }
 }
 
+#[test]
+fn enum_with_different_constructors() {
+    #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+    enum A {
+        A1,
+        A2(u64),
+        A3 { a3: u64 },
+        A4(u64, String),
+        A5 { a51: u64, a52: String},
+        A6(B),
+        A7 { a7: B},
+    }
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+    struct B(Option<C>);
+
+    #[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+    struct C {
+        x: u32,
+        y: u32,
+        z: u32,
+    }
+
+    equivalent! {
+        A::A1, String("A1")
+    }
+
+    equivalent! {
+        A::A2(42),
+        Table(map! {
+            a2: Array(vec![Integer(42)])
+        })
+    }
+
+    equivalent! {
+        A::A3 { a3: 42 },
+        Table(map! {
+            a3: [42]
+        })
+    }
+
+    equivalent! {
+        A::A4(42, String::from("foo")),
+        Table(map! {
+            a4: Array(vec![Integer(42), Value::String("foo".to_string()))
+        })
+    }
+
+    equivalent! {
+        A::A5 { a51: 42, a52: String::from("foo") },
+        Table(map! {
+            a5: Table(map! {
+                a51: Integer(42),
+                a52: Value::String("foo".to_string())
+            })
+        })
+    }
+
+    equivalent! {
+        A::A6(Some({x: 1, y:2, z: 3})),
+        Table(map! {
+            a6: Table(map! {
+                x: Integer(1),
+                y: Integer(2),
+                z: Integer(3)
+            })
+        })
+    }
+
+    equivalent! {
+        A::A7{ a7: Some({x: 1, y:2, z: 3})},
+        Table(map! {
+            a7: Table(map! {
+                x: Integer(1),
+                y: Integer(2),
+                z: Integer(3)
+            })
+        })
+    }
+
+
+
+}
+
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 struct CanBeEmpty {
     a: Option<String>,

--- a/test-suite/tests/serde.rs
+++ b/test-suite/tests/serde.rs
@@ -619,35 +619,35 @@ fn enum_with_different_constructors() {
     equivalent! {
         A::A2(42),
         Table(map! {
-            A2: Array(vec![Integer(42)])
+            A2: Integer(42)
         }),
     }
 
-    equivalent! {
-        A::A3 { a3: 42 },
-        Table(map! {
-            A3: Table(map! {
-                a3: 42
-            })
-        }),
-    }
+    // equivalent! {
+    //     A::A3 { a3: 42 },
+    //     Table(map! {
+    //         A3: Table(map! {
+    //             a3: 42
+    //         })
+    //     }),
+    // }
 
-    equivalent! {
-        A::A4(42, String::from("foo")),
-        Table(map! {
-            A4: Array(vec![Integer(42), Value::String("foo".to_string())])
-        }),
-    }
+    // equivalent! {
+    //     A::A4(42, String::from("foo")),
+    //     Table(map! {
+    //         A4: Array(vec![Integer(42), Value::String("foo".to_string())])
+    //     }),
+    // }
 
-    equivalent! {
-        A::A5 { a51: 42, a52: String::from("foo") },
-        Table(map! {
-            A5: Table(map! {
-                a51: Integer(42),
-                a52: Value::String("foo".to_string())
-            })
-        }),
-    }
+    // equivalent! {
+    //     A::A5 { a51: 42, a52: String::from("foo") },
+    //     Table(map! {
+    //         A5: Table(map! {
+    //             a51: Integer(42),
+    //             a52: Value::String("foo".to_string())
+    //         })
+    //     }),
+    // }
 
     equivalent! {
         A::A6(B(Some(C {x: 1, y:2, z: 3}))),
@@ -660,18 +660,18 @@ fn enum_with_different_constructors() {
         }),
     }
 
-    equivalent! {
-        A::A7{ a7: B(Some(C {x: 1, y:2, z: 3}))},
-        Table(map! {
-            A7: Table(map! {
-                a7: Table(map! {
-                    x: Integer(1),
-                    y: Integer(2),
-                    z: Integer(3)
-                })
-            })
-        }),
-    }
+    // equivalent! {
+    //     A::A7{ a7: B(Some(C {x: 1, y:2, z: 3}))},
+    //     Table(map! {
+    //         A7: Table(map! {
+    //             a7: Table(map! {
+    //                 x: Integer(1),
+    //                 y: Integer(2),
+    //                 z: Integer(3)
+    //             })
+    //         })
+    //     }),
+    // }
 }
 
 #[derive(Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -137,16 +137,19 @@ mod enum_newtype {
     }
 
     #[test]
-    #[ignore = "Unimplemented: https://github.com/alexcrichton/toml-rs/pull/264#issuecomment-431707209"]
     fn from_dotted_table() {
         assert_eq!(
             TheEnum::NewType("value".to_string()),
-            toml::from_str(r#"NewType = "value""#).unwrap()
+            toml::from_str(r#"{ NewType = "value"}"#).unwrap()
         );
+
         assert_eq!(
-            Val {
-                val: TheEnum::NewType("value".to_string()),
-            },
+            Val { val: TheEnum::NewType("value".to_string()) },
+            toml::from_str(r#"val = { NewType = "value" }"#).unwrap()
+        );
+
+        assert_eq!(
+            Val { val: TheEnum::NewType("value".to_string()) },
             toml::from_str(
                 r#"[val]
                 NewType = "value"
@@ -211,6 +214,8 @@ mod enum_array {
         let toml_str = r#"
             enums = [
                 { Plain = {} },
+                { Plain = {} },
+                { Plain = {} },
                 { Tuple = { 0 = -123, 1 = true } },
                 { NewType = "value" },
                 { Struct = { value = -123 } }
@@ -218,6 +223,8 @@ mod enum_array {
         assert_eq!(
             Multi {
                 enums: vec![
+                    TheEnum::Plain,
+                    TheEnum::Plain,
                     TheEnum::Plain,
                     TheEnum::Tuple(-123, true),
                     TheEnum::NewType("value".to_string()),
@@ -229,7 +236,6 @@ mod enum_array {
     }
 
     #[test]
-    #[ignore = "Unimplemented: https://github.com/alexcrichton/toml-rs/pull/264#issuecomment-431707209"]
     fn from_dotted_table() {
         let toml_str = r#"[[enums]]
             Plain = {}

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -144,12 +144,16 @@ mod enum_newtype {
         );
 
         assert_eq!(
-            Val { val: TheEnum::NewType("value".to_string()) },
+            Val {
+                val: TheEnum::NewType("value".to_string())
+            },
             toml::from_str(r#"val = { NewType = "value" }"#).unwrap()
         );
 
         assert_eq!(
-            Val { val: TheEnum::NewType("value".to_string()) },
+            Val {
+                val: TheEnum::NewType("value".to_string())
+            },
             toml::from_str(
                 r#"[val]
                 NewType = "value"

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -140,7 +140,7 @@ mod enum_newtype {
     fn from_dotted_table() {
         assert_eq!(
             TheEnum::NewType("value".to_string()),
-            toml::from_str(r#"{ NewType = "value"}"#).unwrap()
+            toml::from_str(r#"NewType = "value""#).unwrap()
         );
 
         assert_eq!(

--- a/tests/enum_external_deserialize.rs
+++ b/tests/enum_external_deserialize.rs
@@ -126,7 +126,7 @@ mod enum_newtype {
     fn from_inline_table() {
         assert_eq!(
             TheEnum::NewType("value".to_string()),
-            toml::from_str(r#"{ NewType = "value" }"#).unwrap()
+            toml::from_str(r#"NewType = "value""#).unwrap()
         );
         assert_eq!(
             Val {


### PR DESCRIPTION
This PR allows us to serialize/deserialize the TheEnum::Tuple, TheEnum::NewType, TheEnum::Struct variants as well:

```
#[derive(Debug, Deserialize, PartialEq)]
struct Val {
    val: TheEnum,
}

#[derive(Debug, Deserialize, PartialEq)]
enum TheEnum {
    Plain,
    Tuple(i64, bool),
    NewType(String),
    Struct { value: i64 },
}
```

The change possibly contains a breaking change because the enum TheEnum::Tuple used to be deserialized to

```
Val { val: TheEnum::Tuple(42, true) }
```

```
val = [42, true]
```
with loss of the variant information, so not enough information to deserialize.

The new behaviour is

```
  [val]
  Tuple = [42, true]
```

Which can now be deserialized.

Please note the change in `from_dotted_table`:

```
TheEnum::NewType("value".to_string())
```

currently does not deserialize correctly (UnsupportedType), and it only deserializes correctly from ```{ NewType = "value"}```. Without the braces it throws a 
```
thread 'enum_newtype::from_dotted_table' panicked at 'called `Result::unwrap()` on an `Err` value: Error { inner: ErrorInner { kind: UnquotedString, line: Some(0), col: 0, at: Some(0), message: "", key: [] } }', tests/enum_external_deserialize.rs:143:52
```

Might need more work around serialization?